### PR TITLE
WIP: UI EOS-12471 start stop service for storage controller

### DIFF
--- a/gui/src/components/maintenance/cortx-resource.vue
+++ b/gui/src/components/maintenance/cortx-resource.vue
@@ -20,7 +20,7 @@
       <label
         id="system-maintenance-title"
         class="cortx-text-lg mt-2 font-weight-bold"
-        >{{$t("systemMaintenance.page-title")}}</label
+        >{{ $t("systemMaintenance.page-title") }}</label
       >
     </div>
     <v-container>
@@ -28,11 +28,12 @@
         <v-card class="col-8 pa-5 elevation-0" outlined tile>
           <v-row class="row-container" align="center" no-gutters>
             <v-col col="3" lg="3">
-              <label id="maintenance-startlbl"
+              <label
+                id="maintenance-startlbl"
                 class="cortx-form-group-label font-weight-bold"
                 for="Resource"
                 style=" font-size: 1em;"
-                >{{$t("systemMaintenance.start-service")}}</label
+                >{{ $t("systemMaintenance.start-service") }}</label
               >
             </v-col>
             <v-col col="3" md="auto" class="mx-3">
@@ -58,7 +59,8 @@
           </v-row>
           <v-row class="mt-5 row-container" align="center" no-gutters>
             <v-col col="3" lg="3">
-              <label id="maintenance-stoplbl"
+              <label
+                id="maintenance-stoplbl"
                 class="cortx-form-group-label font-weight-bold"
                 for="Resource"
                 style=" font-size: 1em;"
@@ -123,12 +125,13 @@
             class="cortx-text-md mt-5 font-weight-bold"
             id="lblShutdownNode"
             v-if="shutdownNode"
-          >{{ $t('systemMaintenance.shutdown-note', { node: shutdownNode }) }}
+          >
+            {{ $t("systemMaintenance.shutdown-note", { node: shutdownNode }) }}
           </div>
         </v-card>
       </div>
       <cortx-confirmation-dialog
-      id="resource-confirmation-dialog"
+        id="resource-confirmation-dialog"
         :show="showConfirmationDialog"
         title="Confirmation"
         :message="confirmationDialogMessage"
@@ -138,7 +141,7 @@
         cancelButtonText="No"
       ></cortx-confirmation-dialog>
       <cortx-confirmation-dialog
-       id="resource-success-dialogbox"
+        id="resource-success-dialogbox"
         :show="showInfoDialog"
         title="Success"
         :message="infoDialogMessage"
@@ -202,28 +205,34 @@ export default class CortxMaintenance extends Vue {
     };
     this.$data.shutdownNode = "";
     try {
-    const res: any = await Api.getAll(apiRegister.node_status);
-    const nodeDetails = res && res.data ? res.data : null;
+      const res: any = await Api.getAll(apiRegister.node_status);
+      const nodeDetails = res && res.data ? res.data : null;
 
-    if (nodeDetails && nodeDetails.node_status) {
-      nodeDetails.node_status.forEach((e: any) => {
-        if (e.online) {
+      if (nodeDetails && nodeDetails.node_status) {
+        nodeDetails.node_status.forEach((e: any) => {
+          if (e.online) {
             if (e.standby) {
               this.$data.resourceState.standby.push(e.name);
+              //added temporary hardcoded storage controller to the start dropdown
+              this.$data.resourceState.standby.push(i18n.t("systemMaintenance.storage-controller"));
             } else {
-          this.$data.resourceState.online.push(e.name);
-        }
+              this.$data.resourceState.online.push(e.name);
+              //added temporary hardcoded storage controller to the start dropdown
+              this.$data.resourceState.online.push(i18n.t("systemMaintenance.storage-controller"));
+            }
             this.$data.resourceState.offline.push(e.name);
           } else {
             this.$data.shutdownNode = e.name;
-        }
-      });
-    }
+          }
+        });
+      }
     } catch (error) {
+      //added temporary hardcoded storage controller to the start dropdown
+      this.$data.resourceState.standby.push(i18n.t("systemMaintenance.storage-controller"));
       this.handleClientCloseRequest(error);
     } finally {
-    this.$store.dispatch("systemConfig/hideLoader");
-  }
+      this.$store.dispatch("systemConfig/hideLoader");
+    }
   }
 
   private async closeConfirmationDialog(confirmation: boolean) {
@@ -263,43 +272,62 @@ export default class CortxMaintenance extends Vue {
   }
 
   private handleClientCloseRequest(error: any) {
-        if (error && error.status === 499) {
-          this.$data.showInfoDialog = true;
-        } else {
-          let errorMessage = i18n.t("systemMaintenance.error-message-onclose");
-          if (error && error.error && error.data.message) {
-            errorMessage = error.data.message;
-          }
-          throw {
-            error: {
-              message: errorMessage
-            }
-          };
+    if (error && error.status === 499) {
+      this.$data.showInfoDialog = true;
+    } else {
+      let errorMessage = i18n.t("systemMaintenance.error-message-onclose");
+      if (error && error.error && error.data.message) {
+        errorMessage = error.data.message;
+      }
+      throw {
+        error: {
+          message: errorMessage
         }
+      };
+    }
   }
   private stopSelectedResource(action: boolean) {
-    this.$data.confirmationDialogMessage =
-      i18n.t("systemMaintenance.confirm-message-node-stop");
-
-    this.$data.actionMethod = i18n.t("systemMaintenance.stop-action-method");
-    this.$data.confirmationDialogSeverity = i18n.t("systemMaintenance.danger-severity");
+    this.$data.confirmationDialogMessage = i18n.t(
+      "systemMaintenance.confirm-message-node-stop"
+    );
+    if (this.$data.resource.stop === i18n.t("systemMaintenance.storage-controller")) {
+      this.$data.actionMethod = i18n.t("systemMaintenance.controller-stop");
+    } else {
+      this.$data.actionMethod = i18n.t("systemMaintenance.stop-action-method");
+    }
+    this.$data.confirmationDialogSeverity = i18n.t(
+      "systemMaintenance.danger-severity"
+    );
     this.$data.showConfirmationDialog = true;
   }
   private startSelectedResource(action: boolean) {
-    this.$data.actionMethod = i18n.t("systemMaintenance.start-action-method");
-    this.$data.confirmationDialogMessage =
-      i18n.t("systemMaintenance.confirm-message-node-start");
-    this.$data.confirmationDialogSeverity = i18n.t("systemMaintenance.info-severity");
+    if (this.$data.resource.start === i18n.t("systemMaintenance.storage-controller")) {
+      this.$data.actionMethod = i18n.t("systemMaintenance.controller-start");
+    } else {
+      this.$data.actionMethod = i18n.t("systemMaintenance.start-action-method");
+    }
+    this.$data.confirmationDialogMessage = i18n.t(
+      "systemMaintenance.confirm-message-node-start"
+    );
+    this.$data.confirmationDialogSeverity = i18n.t(
+      "systemMaintenance.info-severity"
+    );
     this.$data.showConfirmationDialog = true;
   }
   private shutdownSelectedResource(action: boolean) {
-    this.$data.confirmationDialogMessage =
-      i18n.t("systemMaintenance.confirm-message-node-shutdown");
-    this.$data.confirmationDialogSubMessage =
-      i18n.t("systemMaintenance.confirm-message-shutdown-sub");
+    this.$data.confirmationDialogMessage = i18n.t(
+      "systemMaintenance.confirm-message-node-shutdown"
+    );
+    this.$data.confirmationDialogSubMessage = i18n.t(
+      "systemMaintenance.confirm-message-shutdown-sub"
+    );
 
-    this.$data.actionMethod = i18n.t("systemMaintenance.shutdown-action-method");
-    this.$data.confirmationDialogSeverity = i18n.t("systemMaintenance.danger-severity");
+    this.$data.actionMethod = i18n.t(
+      "systemMaintenance.shutdown-action-method"
+    );
+    this.$data.confirmationDialogSeverity = i18n.t(
+      "systemMaintenance.danger-severity"
+    );
     this.$data.showConfirmationDialog = true;
   }
   private createOptionsForDropdown(list: string[]) {

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -86,7 +86,11 @@
     "confirm-message-node-start": "Are you sure, you want to start the node?",
     "confirm-message-node-shutdown": "Are you sure, you want to shutdown the node?",
     "confirm-message-shutdown-sub":"Please note that if you shutdown the node then the entire application will stop",
-    "shutdown-note": "Note: {node} is in shutdown state. You need to start it manually."
+    "shutdown-note": "Note: {node} is in shutdown state. You need to start it manually.",
+    "storage-controller": "Storage Controller",
+    "controller-start": "controller_start",
+    "controller-stop": "controller_stop"
+
   },
   "udx-registration":{
     "udx-registration": "UDX Registration",

--- a/gui/src/services/api-register.ts
+++ b/gui/src/services/api-register.ts
@@ -52,6 +52,8 @@ export default {
   node_shutdown: `/api/${version}/maintenance/cluster/shutdown`,
   node_replace: `/api/${version}/maintenance/cluster/replace_node`,
   node_replace_status: `/api/${version}/maintenance/cluster/replace_node_status`,
+  node_controller_stop: `api/${version}/maintenance/storage_controller/stop`,
+  node_controller_start: `api/${version}/maintenance/storage_controller/start`,
   health_summary: `/api/${version}/system/health/summary`,
   audit_alerts: `/api/${version}/audit_alerts`,
   send_test_email: `/api/${version}/sysconfig_helpers/email_test`,
@@ -65,4 +67,5 @@ export default {
   node_health: `/api/${version}/system/health/node`,
   version: `/api/${version}/product_version`,
   health_components: `api/${version}/system/health/components`
+
 };


### PR DESCRIPTION
# UI

## Problem Statement
<pre>
  <code>
    Story Ref (if any): EOS-12471
Implement stat/stop service functionality for storage controller
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
Implement stat/stop service functionality for storage controller
  </code>
</pre>
## Solution/Screenshots

<pre>
  <code>

- Currently added hardcoded "storage controller" option in Start service dropdown
- Integrated backend python API to start/stop service

Note: This feature in in progress as currently we don't have the data in following API which is in progress to show name in drop down
GET /api/v1/maintenance/storage_controller/status

  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
  </code>
</pre>