### PR TITLE
s3 account deletion issue

### DIFF
--- a/gui/src/components/s3/account-management.vue
+++ b/gui/src/components/s3/account-management.vue
@@ -609,7 +609,11 @@ export default class CortxAccountManagement extends Vue {
       { text: "", value: "data-table-expand" }
     ];
   }
-
+  public data() {
+    return {
+      constStr: require("./../../common/const-string.json")
+    };
+  }
   public async mounted() {
     await this.getAllAccounts();
   }
@@ -730,6 +734,7 @@ export default class CortxAccountManagement extends Vue {
     );
     await Api.delete(apiRegister.s3_account, this.accountToDelete);
     this.$store.dispatch("systemConfig/hideLoader");
+    localStorage.removeItem(this.$data.constStr.username);
     this.$router.push("/login");
   }
 }


### PR DESCRIPTION
# UI
S3 Account deletion issue

## Problem Statement
<pre>
  <code>
   After s3 account deletion it should redirect to the login page
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Tested changes on locally
  </code>
</pre>
## Problem Description
<pre>
  <code>
- S3 account deletion removed username from local storage

  </code>
</pre>
## Solution/Screenshots
![image](https://user-images.githubusercontent.com/64768901/92899998-ef67e500-f43c-11ea-95fd-926c27587bbf.png)


  <code>
  </code>
</pre>