### PR TITLE
Fixed gitopts parameter for BRAND in ./cicd/build.sh

### DIFF
--- a/cicd/build.sh
+++ b/cicd/build.sh
@@ -63,7 +63,7 @@ while getopts ":g:v:b:p:n:l:k:c:tdiq" o; do
         p)
             PRODUCT=${OPTARG}
             ;;
-        l)
+        n)
             BRAND=${OPTARG}
             ;;
         l)


### PR DESCRIPTION
Hi @kupranay  - I observed that there is issue in `build.sh` while adding support for `cortx-1.0` branch support in custom-ci . Hence added this fix. Can you please review and merge. 