### PR TITLE
EOS-13241:Minimum characters length is not honored for Appliance name…

### DIFF
--- a/gui/src/components/onboarding/system-config/appliance-name/appliance-name-config.vue
+++ b/gui/src/components/onboarding/system-config/appliance-name/appliance-name-config.vue
@@ -36,7 +36,7 @@
                 >{{ $t("onBoarding.enterValidSystemName") }}</label
               >
               <label v-else-if="$v.appliance.$dirty && !$v.appliance.minLength"
-                >{{ $t("onBoarding.minimumFourChartSystemName") }}</label
+                >{{ $t("onBoarding.minimumTwoChartSystemName") }}</label
               >
               <label v-else-if="$v.appliance.$dirty && !$v.appliance.maxLength"
               >{{ $t("onBoarding.maxChartSystemName") }}</label>

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -138,7 +138,7 @@
     "addSystemName": "Add System name",
     "systemNameIsReq": "System name is required.",
     "enterValidSystemName": "Enter valid System name.",
-    "minimumFourChartSystemName": "Minimum 4 characters are required.",
+    "minimumTwoChartSystemName": "Minimum 2 characters are required.",
     "maxChartSystemName": "max 255 characters allow."
   }
 }


### PR DESCRIPTION

# UI

 CSM UI : Minimum characters length is not honored for Appliance name field on onboarding page

## Problem Statement
<pre>
  <code>
    Story Ref (if any):EOS-13241
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
adde 2 character min length for appliance name
  </code>
</pre>
## Solution/Screenshots

 
![image](https://user-images.githubusercontent.com/66409360/93165891-dc099200-f73a-11ea-8f42-fbee6f710a09.png)
![image](https://user-images.githubusercontent.com/66409360/93165910-e9bf1780-f73a-11ea-9685-2f1eb9640468.png)



<pre>
  <code>
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
   1)tested  appliance name min length  
  </code>
</pre>… field on onboarding page

Signed-off-by: Jayshree More <jayshree.more@seagate.com>