### PR TITLE
[UI: Dashboard] EOS-12951 Dashboard is not taking full height on larger screens

### DIFF
--- a/gui/src/components/alerts/alert-medium.vue
+++ b/gui/src/components/alerts/alert-medium.vue
@@ -26,12 +26,12 @@
         @click="$router.push('/alerts')"
       />
     </div>
-    <div class="mt-3">
+    <div>
       <v-data-table
         calculate-widths
         :items="alertObject.alerts"
         item-key="updated_time"
-        height="250"
+        height="280"
         :items-per-page.sync="itemsPerPage"
         :footer-props="{
           'items-per-page-options': [50, 100, 150, 200]
@@ -117,11 +117,13 @@
               ></div>
                <div
               style="margin: auto;"
-              v-if="(props.item.severity !== alertStatus.informational) 
-              && (props.item.severity !== alertStatus.warning)
-              && (props.item.severity !== alertStatus.critical 
-              && props.item.severity !== alertStatus.error 
-              && props.item.severity !== alertStatus.alert)"
+                v-if="
+                  props.item.severity !== alertStatus.informational &&
+                    props.item.severity !== alertStatus.warning &&
+                    (props.item.severity !== alertStatus.critical &&
+                      props.item.severity !== alertStatus.error &&
+                      props.item.severity !== alertStatus.alert)
+                "
               :title="props.item.severity"
               class="cortx-status-chip cortx-chip-others"
             ></div>
@@ -200,15 +202,5 @@ export default class CortxAlertMedium extends Mixins(AlertsMixin) {
 .cortx-alert-navigate {
   float: right;
   cursor: pointer;
-}
-@media screen and (min-height: 600px) {
-  #alertMediumContainer {
-    padding-left: 20px;
-  }
-}
-@media screen and (min-height: 900px) {
-  #alertMediumContainer {
-    padding: 20px;
-  }
 }
 </style>

--- a/gui/src/components/dashboard/dashboard.vue
+++ b/gui/src/components/dashboard/dashboard.vue
@@ -15,17 +15,17 @@
 * please email opensource@seagate.com or cortx-questions@seagate.com.
 */
 <template>
-  <div class="cortx-p-2">
-    <v-row style="border-bottom: 2px solid rgba(0, 0, 0, 0.12);">
+  <div class="cortx-p-1" id="dashboardContainer">
+    <v-row id="statsRowContainer" class="row-container">
       <v-col class="pt-0" cols="12">
         <cortx-stats-medium />
       </v-col>
     </v-row>
-    <v-row>
-      <v-col cols="4" style="border-right: 2px solid rgba(0, 0, 0, 0.12);">
-        <cortx-capacity-guage />
+    <v-row id="alertCapacityRowContainer" class="row-container">
+      <v-col cols="4" class="capacity-gauge-container">
+        <cortx-capacity-gauge />
       </v-col>
-      <v-col cols="8">
+      <v-col cols="8" class="pa-3 pb-0">
         <cortx-alert-medium />
       </v-col>
     </v-row>
@@ -36,7 +36,7 @@
 import { Component, Vue } from "vue-property-decorator";
 import CortxAlertMedium from "./../alerts/alert-medium.vue";
 import CortxStatsMedium from "./stats/stats-medium.vue";
-import CortxCapacityGuage from "./capacity-gauge.vue";
+import CortxCapacityGauge from "./capacity-gauge.vue";
 import * as c3 from "c3";
 
 @Component({
@@ -44,7 +44,7 @@ import * as c3 from "c3";
   components: {
     cortxAlertMedium: CortxAlertMedium,
     cortxStatsMedium: CortxStatsMedium,
-    cortxCapacityGuage: CortxCapacityGuage
+    cortxCapacityGauge: CortxCapacityGauge
   }
 })
 export default class Dashboard extends Vue {}
@@ -52,5 +52,11 @@ export default class Dashboard extends Vue {}
 <style lang="scss" scoped>
 .page {
   position: relative;
+}
+.row-container {
+  border-bottom: 2px solid rgba(0, 0, 0, 0.12);
+}
+.capacity-gauge-container {
+  border-right: 2px solid rgba(0, 0, 0, 0.12);
 }
 </style>

--- a/gui/src/components/widgets/line-chart.vue
+++ b/gui/src/components/widgets/line-chart.vue
@@ -71,7 +71,7 @@
             <label class="tab-label" id="sixhrstablbl">6 Hrs</label>
           </v-tab>
           <v-tab @click="tabChange(43200)" id="twelvehrstab">
-            <label class="tab-label" id="twelvehrstablbl" >12 Hrs</label>
+            <label class="tab-label" id="twelvehrstablbl">12 Hrs</label>
           </v-tab>
           <v-tab @click="tabChange(86400)" id="onedaytab">
             <label class="tab-label" id="onedaytablbl">1 Day</label>


### PR DESCRIPTION
# UI

## Problem Statement
<pre>
  <code>
    Story Ref (if any): EOS-12951
Dashboard is not taking full height on larger screens
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
  </code>
</pre>
## Solution/Screenshots
![image](https://user-images.githubusercontent.com/29979122/93474095-8983cd80-f914-11ea-9000-1c9bdb05588c.png)
![image](https://user-images.githubusercontent.com/29979122/93474149-9accda00-f914-11ea-9e53-6ede3c15c35d.png)

<pre>
  <code>
Increased height of alert container datatable
Fixed dashboard styling and typos
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
Tested changes with large and small screens by changing application resolution
  </code>
</pre>