### PR TITLE
EOS-13431:Red dot on Alert notification does not changes it's state until user refreshes the page.

### DIFF
--- a/gui/src/mixins/alerts.ts
+++ b/gui/src/mixins/alerts.ts
@@ -91,6 +91,7 @@ export default class AlertsMixin extends Vue {
       show: false,
       message: ""
     });
+    this.$store.dispatch("alertDataAction");
   }
 
   public async acknowledgeAlert(alert: any) {
@@ -112,6 +113,7 @@ export default class AlertsMixin extends Vue {
       show: false,
       message: ""
     });
+    this.$store.dispatch("alertDataAction");
   }
 
   get currentPage() {


### PR DESCRIPTION

# UI

 CSM UI : EOS-13431:Red dot on Alert notification does not changes it's state until user refreshes the page.

## Problem Statement
<pre>
  <code>
    Story Ref (if any):EOS-13431
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
EOS-13431:Red dot on Alert notification does not changes it's state until user refreshes the page.
  </code>
</pre>
## Solution/Screenshots

 
![image](https://user-images.githubusercontent.com/66409360/93664124-33d13180-fa8a-11ea-95dc-ad133e629c40.png)



<pre>
  <code>
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
   1)tested Red dot on Alert notification does not change or not
  </code>
</pre>Signed-off-by: Jayshree More <jayshree.more@seagate.com>