### PR TITLE
[dev]:EOS-13477-CSM user with monitor role is able to add comments for alerts

### DIFF
--- a/gui/src/components/alerts/alert-comments.vue
+++ b/gui/src/components/alerts/alert-comments.vue
@@ -45,6 +45,7 @@
             </div>
           </div>
         </div>
+         <cortx-has-access :to="$cortxUserPermissions.alerts + $cortxUserPermissions.update">
         <div class="cortx-modal-footer">
           <div
             class="cortx-form-group"
@@ -53,12 +54,14 @@
             }"
             style="width: 100%;"
           >
+         
             <textarea
              id="alert-comment-textarea"
               class="cortx-form__input_textarea"
               v-model.trim="addCommentForm.comment_text"
               @input="$v.addCommentForm.comment_text.$touch"
             ></textarea>
+           
             <div class="cortx-form-group-label cortx-form-group-error-msg">
               <label
                 v-if="$v.addCommentForm.comment_text.$dirty && !$v.addCommentForm.comment_text.required"
@@ -84,6 +87,7 @@
             >Save</button>
           </div>
         </div>
+          </cortx-has-access>
       </div>
     </div>
   </div>

--- a/gui/src/components/alerts/alert-large.vue
+++ b/gui/src/components/alerts/alert-large.vue
@@ -192,7 +192,6 @@
               <span>Go to alert details page</span>
             </v-tooltip>
             <div v-if="!(props.item.acknowledged && props.item.resolved)" class="cortx-float-l">
-              <cortx-has-access :to="$cortxUserPermissions.alerts + $cortxUserPermissions.update">
                 <v-tooltip left>
                   <template v-slot:activator="{ on, attrs }">
                     <div
@@ -204,6 +203,7 @@
                   </template>
                   <span>Add comments</span>
                 </v-tooltip>
+                <cortx-has-access :to="$cortxUserPermissions.alerts + $cortxUserPermissions.update">
                 <v-tooltip left>
                   <template v-slot:activator="{ on, attrs }">
                     <div
@@ -215,7 +215,7 @@
                   </template>
                   <span>{{ props.item.acknowledged ? "Unacknowledge alert" : "Acknowledge alert" }}</span>
                 </v-tooltip>
-              </cortx-has-access>
+                </cortx-has-access>
             </div>
           </td>
         </tr>


### PR DESCRIPTION

# UI

 CSM UI :CSM user with monitor role is able to add comments for alerts

## Problem Statement
<pre>
  <code>
    Story Ref (if any):EOS-13477
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
CSM user with monitor role is able to add comments for alerts
  </code>
</pre>
## Solution/Screenshots

 
![image](https://user-images.githubusercontent.com/66409360/93857830-d848b300-fcd8-11ea-921e-e6679cb36a75.png)
![image](https://user-images.githubusercontent.com/66409360/93857883-eac2ec80-fcd8-11ea-9ea6-b0ad3866cfec.png)
![image](https://user-images.githubusercontent.com/66409360/93857965-104ff600-fcd9-11ea-93db-64a0ace9f4f4.png)




<pre>
  <code>
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
   1)login as a csm user with role monitor
  2) check monitor user can able  view comment or not
 3) check monitor user must not be able to  add comment . 
4) login as admin manager user
5)check admin user can able to add comment or not
  </code>
</pre>Signed-off-by: Jayshree More <jayshree.more@seagate.com>