### PR TITLE
[cortx1.0-dev] EOS-13492: Adding generic template to show license.

### DIFF
--- a/gui/src/components/preboarding/license-agreement.vue
+++ b/gui/src/components/preboarding/license-agreement.vue
@@ -18,9 +18,9 @@
   <div>
     <v-container>
       <div class="cortx-modal-container">
-        <div class="cortx-modal cortx-modal-onboarding">
+        <div class="cortx-modal cortx-license-modal">
           <div class="cortx-modal-header">
-            <label id="agreement-title"> {{ agreementText.title }}</label>
+            <label id="agreement-title"> {{ agreementText.heading }}</label>
             <img
               id="license-cancelagreementicon"
               class="cortx-modal-close"
@@ -30,7 +30,40 @@
           </div>
           <div class="cortx-modal-body ">
             <div class="title-container pr-3" id="agreement-data">
-              <div v-html="agreementText.description" id="agreement-discription"></div>
+              <div
+                class="font-weight-bold text-center mb-5"
+              >
+                {{ agreementText.sub_heading }}
+              </div>
+              <template v-for="(section, index) in agreementText.sections">
+                <div v-bind:key="index">
+                  <div v-if="section.paragraph_text">
+                    <label class="title-text" v-if="section.paragraph_text.title">
+                      {{ section.paragraph_text.title }}
+                    </label>
+                    <p v-cortx-build-link>{{ section.paragraph_text.text }}</p>
+                  </div>
+                  <div v-if="section.bulleted_text">
+                    <div class="mb-2" v-if="section.bulleted_text.title">
+                      <label class="title-text">
+                        {{ section.bulleted_text.title }}
+                      </label>
+                    </div>
+                    <ol class="ordered-list">
+                      <template v-for="(text_item, index) in section.bulleted_text.texts">
+                        <li v-bind:key="index" :class="{'font-weight-bold': text_item.title}">
+                          <span
+                            style="text-decoration: underline;"
+                          >
+                            {{ text_item.title }}
+                          </span>
+                          <p class="cortx-font-weight-normal" v-for="(text, index) in text_item.texts" v-bind:key="index" v-cortx-build-link>{{ text }}</p>
+                        </li>
+                      </template>
+                    </ol>
+                  </div>
+                </div>
+              </template>
             </div>
             <div class="mt-5 nav-btn">
               <button
@@ -60,8 +93,11 @@
 <script lang="ts">
 import { Component, Vue, Prop } from "vue-property-decorator";
 import { agreementText } from "./../../common/license-agreement-text";
+import { buildLinkDirective } from "../widgets/build-link-directive";
+
 @Component({
-  name: "cortx-onboarding-finish"
+  name: "cortx-onboarding-finish",
+  directives: { "cortx-build-link": buildLinkDirective }
 })
 export default class CortxOnboardingFinish extends Vue {
   private data() {
@@ -79,8 +115,8 @@ export default class CortxOnboardingFinish extends Vue {
 </script>
 
 <style lang="scss" scoped>
-.cortx-modal-onboarding {
-  width: 730px;
+.cortx-license-modal {
+  width: 760px;
   min-height: 214px;
   height: 535px;
   position: fixed;
@@ -88,17 +124,19 @@ export default class CortxOnboardingFinish extends Vue {
 .nav-btn {
   text-align: right;
 }
-.finish-text {
-  vertical-align: center;
-  float: left;
-}
-.success-img {
-  margin-top: 3px;
-  float: left;
-}
 .title-container {
   height: 376px;
   overflow: auto;
   text-align: justify;
+}
+.ordered-list {
+  list-style-type: upper-roman;
+}
+.cortx-font-weight-normal {
+  font-weight: normal;
+}
+.title-text {
+  font-weight: bold;
+  text-decoration: underline;
 }
 </style>

--- a/gui/src/components/widgets/build-link-directive.ts
+++ b/gui/src/components/widgets/build-link-directive.ts
@@ -14,22 +14,21 @@
 * For any questions about this software or licensing,
 * please email opensource@seagate.com or cortx-questions@seagate.com.
 */
-export const agreementText = {
-  heading: "CORTX Agreement",
-  sub_heading: "CORTX Terms and Conditions",
-  sections: [
-    {
-      paragraph_text: {
-        title: "",
-        text: `
-                CORTX community is happy to provide this for the convenience of the community to test CORTX.
-                This is provided merely for testing purposes and is supported through CORTX community.
-                Users should use this only for testing purposes and should not store any critical data on it.
-                Use and enjoy but do so at your own risk.
-                For questions about CORTX, please use the appropriate community channels at
-                https://github.com/Seagate/ .
-              `
-      }
+import { DirectiveOptions } from "vue";
+
+const createURL = (text: string) => {
+    const urlRegex = /(https?:\/\/[^\s]+)/g;
+    return text.replace(urlRegex, (url: string) => {
+        return "<a href=" + url + " target='_blank'>" + url + "</a>";
+    });
+};
+
+const buildLinkDirective: DirectiveOptions = {
+    bind: (el, binding, vnode) => {
+        el.innerHTML = createURL(el.innerText);
     }
-  ]
+};
+
+export {
+    buildLinkDirective
 };


### PR DESCRIPTION
# Front-end 

## Problem Statement
<pre>
  <code>
Story Ref (if any): EOS-13492 : Create framework for configuring License text based on deployment type and should be configurable
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
 NOT Required
  </code>
</pre>
## Problem Description
<pre>
  <code>
Need a generic template for license text.
  </code>
</pre>
## Solution
<pre>
  <code>
Added a generic template for license text.

{
  heading: "",
  sub_heading: "",
  sections: [
    {
      paragraph_text: {
        title: "",
        text: ""
      }
    },
   {
      bulleted_text: {
        title: "",
        texts: [
         {
           title: "",
           texts: ["", ""]
         }
        ]
      }
    }
  ]
}
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
- NOT required
  </code>
</pre>

![license-1](https://user-images.githubusercontent.com/66473115/94140040-48e20200-fe88-11ea-9609-5e69fd23ab70.jpg)
![license-2](https://user-images.githubusercontent.com/66473115/94140045-4a132f00-fe88-11ea-9741-02665ab70b44.jpg)
![license-3](https://user-images.githubusercontent.com/66473115/94140047-4aabc580-fe88-11ea-83b9-7378599d1758.jpg)
![license-4](https://user-images.githubusercontent.com/66473115/94140050-4b445c00-fe88-11ea-989d-ee8ede563735.jpg)
![license-5](https://user-images.githubusercontent.com/66473115/94140053-4bdcf280-fe88-11ea-8451-865b5baa809e.jpg)


Signed-off-by: Shri Bhargav Metta <shri.metta@seagate.com>