### PR TITLE
[main]EOS-13692: Swagger- Show audit logs for csm GET query not getting executed even after providing the required fields

### DIFF
--- a/web/src/config/client_swagger.json
+++ b/web/src/config/client_swagger.json
@@ -1996,13 +1996,6 @@
 						"type": "string"
 					},
 					{
-						"name": "component",
-						"in": "path",
-						"description": "Specifies the component",
-						"required": true,
-						"type": "string"
-					},
-					{
 						"name": "start_date",
 						"in": "query",
 						"description": "epoch time",
@@ -2070,13 +2063,6 @@
 						"name": "component",
 						"in": "path",
 						"description": "Specifies the component (csm or s3)",
-						"required": true,
-						"type": "string"
-					},
-					{
-						"name": "component",
-						"in": "path",
-						"description": "Specifies the component",
 						"required": true,
 						"type": "string"
 					},

--- a/web/src/config/swagger.json
+++ b/web/src/config/swagger.json
@@ -2615,13 +2615,6 @@
 						"type": "string"
 					},
 					{
-						"name": "component",
-						"in": "path",
-						"description": "Specifies the component",
-						"required": true,
-						"type": "string"
-					},
-					{
 						"name": "start_date",
 						"in": "query",
 						"description": "epoch time",
@@ -2689,13 +2682,6 @@
 						"name": "component",
 						"in": "path",
 						"description": "Specifies the component (csm or s3)",
-						"required": true,
-						"type": "string"
-					},
-					{
-						"name": "component",
-						"in": "path",
-						"description": "Specifies the component",
 						"required": true,
 						"type": "string"
 					},


### PR DESCRIPTION
# Front-end 

## Problem Statement
<pre>
  <code>
Story Ref (if any): EOS-13692: Swagger- Show audit logs for csm GET query not getting executed even after providing the required fields
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
No
  </code>
</pre>
## Problem Description
<pre>
  <code>
Audit logs not working in swagger
  </code>
</pre>
## Solution
<pre>
  <code>
Removed duplicate parameter
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
- done on local
  </code>
</pre>