### PR TITLE
[cortx]:Node names Under drop-downs on System maintenance page should display hostname /FQDN instead of srvnode1/2

### DIFF
--- a/gui/src/components/maintenance/cortx-resource.vue
+++ b/gui/src/components/maintenance/cortx-resource.vue
@@ -209,11 +209,11 @@ export default class CortxMaintenance extends Vue {
       nodeDetails.node_status.forEach((e: any) => {
         if (e.online) {
             if (e.standby) {
-              this.$data.resourceState.standby.push(e.name);
+              this.$data.resourceState.standby.push(e.hostname);
             } else {
-          this.$data.resourceState.online.push(e.name);
+          this.$data.resourceState.online.push(e.hostname);
         }
-            this.$data.resourceState.offline.push(e.name);
+            this.$data.resourceState.offline.push(e.hostname);
           } else {
             this.$data.shutdownNode = e.name;
         }


### PR DESCRIPTION
Signed-off-by: Jayshree More <jayshree.more@seagate.com>
# UI

 CSM UI : Node names Under drop-downs on System maintenance page should display hostname /FQDN instead of srvnode1/2

## Problem Statement
<pre>
  <code>
    Story Ref (if any):EOS-13768
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
  </code>
</pre>
## Solution/Screenshots

 

![image](https://user-images.githubusercontent.com/66409360/94597838-b4263c80-02ab-11eb-8a58-adcba2687a36.png)




<pre>
  <code>
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
   1)tested  with back-end data
  </code>
</pre>