### PR TITLE
[Cortx1.0-dev] EOS-11603: CSM: Edit comment using patch for Alert command is not working

### DIFF
--- a/web/src/config/client_swagger.json
+++ b/web/src/config/client_swagger.json
@@ -1328,7 +1328,7 @@
 			},
 			"patch": {
 				"tags": ["Alerts"],
-				"summary": "Edit Alert: Accessible to CSM users having manage permission",
+				"summary": "Edit Alert: Accessible to CSM users having manage permission and it will update the acknowledge flag",
 				"responses": {
 					"200": {
 						"description": "OK"
@@ -1383,10 +1383,6 @@
 						"properties": {
 							"acknowledged": {
 								"type": "boolean"
-							},
-							"comments": {
-								"type": "string",
-								"example": ""
 							}
 						}
 					}

--- a/web/src/config/swagger.json
+++ b/web/src/config/swagger.json
@@ -1798,7 +1798,7 @@
 			},
 			"patch": {
 				"tags": ["Alerts"],
-				"summary": "Edit Alert: Accessible to CSM users having manage permission",
+				"summary": "Edit Alert: Accessible to CSM users having manage permission and it will update the acknowledge flag",
 				"responses": {
 					"200": {
 						"description": "OK"
@@ -1853,10 +1853,6 @@
 						"properties": {
 							"acknowledged": {
 								"type": "boolean"
-							},
-							"comments": {
-								"type": "string",
-								"example": ""
 							}
 						}
 					}


### PR DESCRIPTION
# Front-end 

## Problem Statement
<pre>
  <code>
Story Ref (if any): EOS-11603: CSM: Edit comment using patch for Alert command is not working
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
No
  </code>
</pre>
## Problem Description
<pre>
  <code>
Edit comment using patch for Alert command is not working
  </code>
</pre>
## Solution
<pre>
  <code>
Removed comments from request body of old API /alerts/{alert_id}
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
- done on local
  </code>
</pre>