### PR TITLE
Update date-time-config.vue

### DIFF
--- a/gui/src/components/onboarding/system-config/date-time/date-time-config.vue
+++ b/gui/src/components/onboarding/system-config/date-time/date-time-config.vue
@@ -43,7 +43,7 @@
                 v-model.trim="setDateTime.NtpServerAddress"
                 id="txtDTHostname"
                 @input="$v.setDateTime.NtpServerAddress.$touch"
-                placeholder="time.seagate.com"
+                placeholder="ntp-b.nist.gov"
               />
               <div class="cortx-form-group-label cortx-form-group-error-msg">
                 <label id="ntp-server-required"


### PR DESCRIPTION
Now that we are open source I think we should direct people towards more open servers like NIST and suggest that as an NTP server.

Also our documentation points them towards `ntp-b.nist.gov`  https://github.com/Seagate/cortx/blob/main/doc/Preboarding_and_Onboarding.rst


Signed-off-by: Justin Woo <justin.woo@seagate.com>