### PR TITLE
[Main]EOS-14047-Auditlog page does not show any loader on screen and View button is enabled

### DIFF
--- a/gui/src/components/maintenance/auditlog.vue
+++ b/gui/src/components/maintenance/auditlog.vue
@@ -41,8 +41,8 @@
         ></cortx-dropdown>
       </div>
       <div class="mt-8 nav-btn">
-        <button type="button" class="cortx-btn-primary mr-2" @click="downloadAuditLogs()" id="auditlog-downlodbtn">Download</button>
-        <button type="button" class="cortx-btn-primary" @click="showAuditLogs()" id="auditlog-viewbtn">View</button>
+        <button type="button" class="cortx-btn-primary mr-2" @click="downloadAuditLogs()" id="auditlog-downlodbtn" :disabled="!component||!timerangeLabel">Download</button>
+        <button type="button" class="cortx-btn-primary" @click="showAuditLogs()" id="auditlog-viewbtn" :disabled="!component||!timerangeLabel">View</button>
       </div>
     </div>
     <div class="ma-3 mt-5" v-if="showLog">
@@ -62,7 +62,7 @@ import moment from "moment";
 export default class CortxAuditLog extends Vue {
   private data() {
     return {
-      component: "CSM",
+      component: "",
       componentList: [
         {
           label: "CSM",
@@ -74,7 +74,7 @@ export default class CortxAuditLog extends Vue {
         }
       ],
       timerange: "1",
-      timerangeLabel: "One day",
+      timerangeLabel: "",
       timerangeList: [
         {
           label: "One day",
@@ -125,12 +125,14 @@ export default class CortxAuditLog extends Vue {
       })
       .then(response => {
         this.$data.showLog = response.data;
+        this.$store.dispatch("systemConfig/hideLoader");
       })
       .catch(() => {
         // tslint:disable-next-line: no-console
         console.error("Show audit log failed");
+        this.$store.dispatch("systemConfig/hideLoader");
       });
-    this.$store.dispatch("systemConfig/hideLoader");
+    
   }
   private downloadAuditLogs() {
     this.$store.dispatch(
@@ -161,12 +163,13 @@ export default class CortxAuditLog extends Vue {
         );
         document.body.appendChild(link);
         link.click();
+      this.$store.dispatch("systemConfig/hideLoader");
       })
       .catch(() => {
         // tslint:disable-next-line: no-console
         console.error("download failed");
+        this.$store.dispatch("systemConfig/hideLoader");
       });
-    this.$store.dispatch("systemConfig/hideLoader");
   }
   private handleTimerangeDropdownSelect(selected: any) {
     this.$data.timerange = selected.value;


### PR DESCRIPTION

# UI

 CSM UI : Auditlog page does not show any loader on screen and View button is enabled

## Problem Statement
<pre>
  <code>
    Story Ref (if any):EOS-14047
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
Auditlog page does not show any loader on screen and View button is enabled
  </code>
</pre>
## Solution/Screenshots

 
![image](https://user-images.githubusercontent.com/66409360/95299398-49709480-089b-11eb-892c-7dd2bae18d78.png)
![image](https://user-images.githubusercontent.com/66409360/95299535-83419b00-089b-11eb-8f18-dfffe007c1e8.png)




<pre>
  <code>
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
   1)tested  audit log pages   
  </code>
</pre>Signed-off-by: Jayshree More <jayshree.more@seagate.com>