### PR TITLE
[main] Resolve empty about page

### DIFF
--- a/gui/src/components/maintenance/cortx-about.vue
+++ b/gui/src/components/maintenance/cortx-about.vue
@@ -60,7 +60,7 @@
         </tr>
       </table>
     </div>
-    <v-expansion-panels v-if="versionDetails.COMPONENTS" class="mt-2">
+    <v-expansion-panels v-if="versionDetails.COMPONENTS.length" class="mt-2">
       <v-expansion-panel>
         <v-expansion-panel-header
           class="cortx-text-lg font-weight-bold">
@@ -86,10 +86,15 @@ import i18n from "./../../i18n";
   name: "cortx-about"
 })
 export default class Cortxaboutpage extends Vue {
-  public versionDetails: any = null;
   public data() {
     return {
-      component: "CSM"
+      versionDetails: {
+        NAME: '-' as string,
+        VERSION: '-' as string,
+        BUILD: '-' as string,
+        RELEASE: null,
+        COMPONENTS: []
+      }
     };
   }
 
@@ -99,7 +104,7 @@ export default class Cortxaboutpage extends Vue {
 
   public async getVersion() {
     const res = await Api.getAll(apiRegister.version);
-    this.versionDetails = res.data;
+    this.$data.versionDetails = res.data;
   }
 }
 </script>


### PR DESCRIPTION
# Front-end 

## Problem Statement
<pre>
  <code>
Story Ref (if any): EOS-14046 About page goes blank for sometime while fetching data
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
 NOT Required
  </code>
</pre>
## Problem Description
<pre>
  <code>
About us page should not be blank ever, even if it is fetching data.
  </code>
</pre>
## Solution
<pre>
  <code>
    Set data with versionDetails instead of just variable and set values empty strings.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
- NOT required
  </code>
</pre>


![image](https://user-images.githubusercontent.com/64767189/95337392-6a52dd00-08cf-11eb-87f6-f6ddc44b0e3c.png)
