### PR TITLE
[main] EOS-14144: Send test mail wrong error message issue fix.

### DIFF
--- a/gui/src/store/modules/system-configuration.ts
+++ b/gui/src/store/modules/system-configuration.ts
@@ -214,7 +214,7 @@ export default class SystemConfiguration extends VuexModule {
   @Action
   public async sendTestEmailNotification(payload: any) {
     try {
-      const res = await Api.post(apiRegister.send_test_email, payload);
+      const res = await Api.post(apiRegister.send_test_email, payload, { timeout: 120000 });
       if (res && res.data) {
         const data = res.data;
         return data;


### PR DESCRIPTION
# Front-end 

## Problem Statement
<pre>
  <code>
Story Ref (if any): 
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
 NOT Required
  </code>
</pre>
## Problem Description
<pre>
  <code>
Send Test Mail Functionality Showing wrong error message even though the functionality is working
  </code>
</pre>
## Solution
<pre>
  <code>
Increased the timeout of send test mail api to 2 minutes.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
- NOT required
  </code>
</pre>


Signed-off-by: Shri Bhargav Metta <shri.metta@seagate.com>