### PR TITLE
[cortx1.0-dev] EOS-14190: Alert details showing blank on CSM GUI

### DIFF
--- a/gui/src/components/alerts/alert-details.vue
+++ b/gui/src/components/alerts/alert-details.vue
@@ -92,7 +92,7 @@
           <label
             :class="alert.resolved ? '' : 'cortx-alert-status-chip-disabled'"
             style="float: left;"
-          >{{ $t("alerts.Resolved") }} |</label>
+          >{{ $t("alerts.resolved") }} |</label>
           <img
             v-if="alert.acknowledged"
             class="cortx-float-l"
@@ -102,7 +102,7 @@
           <label
             :class="alert.acknowledged ? '' : 'cortx-alert-status-chip-disabled'"
             style="float: left;"
-          >{{ $t("alerts.Acknowledged") }}</label>
+          >{{ $t("alerts.acknowledged") }}</label>
         </div>
         <div class="cortx-float-r">
           <label
@@ -230,29 +230,13 @@ export default class CortxAlertDetails extends Vue {
       this.alert = res.data;
       try {
         if (this.alert.extended_info) {
-          /**
-           * The string in alert.extended_info is not a valid JSON string (as designed by backend).
-           * To make it a valid JSON string and convert to JSON object, we need to replace single quote
-           * with double quote. The below statement does that.
-           */
-          const tempAlertExtendedInfoJSONString = this.alert.extended_info
-            .split("'")
-            .join("\"");  // Do not change this to "'"
-          this.alertDetails = JSON.parse(tempAlertExtendedInfoJSONString);
+          this.alertDetails = JSON.parse(this.alert.extended_info);
           this.alertExtendedInfo = this.alertDetails.info;
         }
 
         let tempAlertEventDetails = [];
         if (this.alert.event_details) {
-          /**
-           * The string in alert.event_details is not a valid JSON string (as designed by backend).
-           * To make it a valid JSON string and convert to JSON object, we need to replace single quote
-           * with double quote. The below statement does that.
-           */
-          const tempAlertEventDetailsJSONString = this.alert.event_details
-            .split("'")
-            .join("\"");  // Do not change this to "'"
-          tempAlertEventDetails = JSON.parse(tempAlertEventDetailsJSONString);
+          tempAlertEventDetails = JSON.parse(this.alert.event_details);
         }
         if (tempAlertEventDetails.length > 0) {
           tempAlertEventDetails.forEach((event_detail: any) => {

--- a/gui/src/components/alerts/alert-history-details.vue
+++ b/gui/src/components/alerts/alert-history-details.vue
@@ -207,29 +207,13 @@ export default class CortxAlertHistory extends Vue {
       this.alert = res.data;
       try {
         if (this.alert.extended_info) {
-          /**
-           * The string in alert.extended_info is not a valid JSON string (as designed by backend).
-           * To make it a valid JSON string and convert to JSON object, we need to replace single quote
-           * with double quote. The below statement does that.
-           */
-          const tempAlertExtendedInfoJSONString = this.alert.extended_info
-            .split("'")
-            .join("\"");  // Do not change this to "'"
-          this.alertDetails = JSON.parse(tempAlertExtendedInfoJSONString);
+          this.alertDetails = JSON.parse(this.alert.extended_info);
           this.alertExtendedInfo = this.alertDetails.info;
         }
 
         let tempAlertEventDetails = [];
         if (this.alert.event_details) {
-          /**
-           * The string in alert.event_details is not a valid JSON string (as designed by backend).
-           * To make it a valid JSON string and convert to JSON object, we need to replace single quote
-           * with double quote. The below statement does that.
-           */
-          const tempAlertEventDetailsJSONString = this.alert.event_details
-            .split("'")
-            .join("\"");  // Do not change this to "'"
-          tempAlertEventDetails = JSON.parse(tempAlertEventDetailsJSONString);
+          tempAlertEventDetails = JSON.parse(this.alert.event_details);
         }
         if (tempAlertEventDetails.length > 0) {
           tempAlertEventDetails.forEach((event_detail: any) => {


### PR DESCRIPTION
# Front-end 

## Problem Statement
<pre>
  <code>
Story Ref (if any): EOS-14190
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
 NOT Required
  </code>
</pre>
## Problem Description
<pre>
  <code>
Alert details showing blank on CSM GUI for raid integrity alert.
  </code>
</pre>
## Solution
<pre>
  <code>
Removed temporary logic to replace single quote with double quote.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
- NOT required
  </code>
</pre>


Signed-off-by: Shri Bhargav Metta <shri.metta@seagate.com>