### PR TITLE
[CORTX] EOS-14574 changes for capacity chart legend color issue

### DIFF
--- a/gui/src/components/dashboard/capacity-gauge.vue
+++ b/gui/src/components/dashboard/capacity-gauge.vue
@@ -61,22 +61,25 @@ import * as c3 from "c3";
 export default class CortxCapacityGauge extends Vue {
 
   public usedLegendClass = "capacity-used-green";
-  public chartDataVal: number;
+  public chartDataVal;
   public created() {
     const demoData = [["x", 0]];
     const capacityRes = this.$store
       .dispatch("performanceStats/getCapacityStats")
       .then(capacityC3Data => {
-        this.chartDataVal = capacityC3Data[0][1] ? capacityC3Data[0][1] : 0.00;
-        if (this.chartDataVal < 50.00) {
-          this.usedLegendClass = "capacity-used-green";
-        }
-        if (this.chartDataVal >= 50.00) {
-          this.usedLegendClass = "capacity-used-orange";
-        }
-        if (this.chartDataVal >= 90.00) {
-          this.usedLegendClass = "capacity-used-red";
-        }
+        if (capacityC3Data) {
+          this.chartDataVal = capacityC3Data[0][1] ? capacityC3Data[0][1] : 0.00;
+          this.chartDataVal = parseFloat(this.chartDataVal).toFixed(2);
+          if (this.chartDataVal < 50.00) {
+            this.usedLegendClass = "capacity-used-green";
+          }
+          if (this.chartDataVal >= 50.00) {
+            this.usedLegendClass = "capacity-used-orange";
+          }
+          if (this.chartDataVal >= 90.00) {
+            this.usedLegendClass = "capacity-used-red";
+          }
+        } 
         const chart = c3.generate({
           bindto: "#gauge_capacity",
           legend: {

--- a/gui/src/components/dashboard/capacity-gauge.vue
+++ b/gui/src/components/dashboard/capacity-gauge.vue
@@ -61,7 +61,7 @@ import * as c3 from "c3";
 export default class CortxCapacityGauge extends Vue {
 
   public usedLegendClass = "capacity-used-green";
-  public chartDataVal;
+  public chartDataVal: number;
   public created() {
     const demoData = [["x", 0]];
     const capacityRes = this.$store
@@ -69,14 +69,13 @@ export default class CortxCapacityGauge extends Vue {
       .then(capacityC3Data => {
         if (capacityC3Data) {
           this.chartDataVal = capacityC3Data[0][1] ? capacityC3Data[0][1] : 0.00;
-          this.chartDataVal = parseFloat(this.chartDataVal).toFixed(2);
-          if (this.chartDataVal < 50.00) {
+          if (this.chartDataVal < 50) {
             this.usedLegendClass = "capacity-used-green";
           }
-          if (this.chartDataVal >= 50.00) {
+          if (this.chartDataVal >= 50) {
             this.usedLegendClass = "capacity-used-orange";
           }
-          if (this.chartDataVal >= 90.00) {
+          if (this.chartDataVal >= 90) {
             this.usedLegendClass = "capacity-used-red";
           }
         } 

--- a/gui/src/components/dashboard/capacity-gauge.vue
+++ b/gui/src/components/dashboard/capacity-gauge.vue
@@ -68,10 +68,10 @@ export default class CortxCapacityGauge extends Vue {
       .dispatch("performanceStats/getCapacityStats")
       .then(capacityC3Data => {
         this.chartDataVal = capacityC3Data[0][1] ? capacityC3Data[0][1] : 0.00;
-        if (this.chartDataVal <= 50.00) {
+        if (this.chartDataVal < 50.00) {
           this.usedLegendClass = "capacity-used-green";
         }
-        if (this.chartDataVal > 50.00) {
+        if (this.chartDataVal >= 50.00) {
           this.usedLegendClass = "capacity-used-orange";
         }
         if (this.chartDataVal >= 90.00) {

--- a/gui/src/components/dashboard/capacity-gauge.vue
+++ b/gui/src/components/dashboard/capacity-gauge.vue
@@ -68,7 +68,7 @@ export default class CortxCapacityGauge extends Vue {
       .dispatch("performanceStats/getCapacityStats")
       .then(capacityC3Data => {
         if (capacityC3Data) {
-          this.chartDataVal = capacityC3Data[0][1] ? capacityC3Data[0][1] : 0.00;
+          this.chartDataVal = capacityC3Data[0][1] ? capacityC3Data[0][1] : 0;
           if (this.chartDataVal < 50) {
             this.usedLegendClass = "capacity-used-green";
           }


### PR DESCRIPTION
# UI

Capacity chart legend color issue

## Problem Statement
<pre>
  <code>
    Story Ref (if any):EOS-14574
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
CSM GUI: Color of capacity tile and used capacity on the dashboard is mismatch when used capacity is at 50 % </code>
</pre>
## Solution/Screenshots
![image](https://user-images.githubusercontent.com/64768901/96848972-af037a00-1472-11eb-8ca1-8bf3e194481e.png)

<pre>
  <code>
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
  tested on locally
  </code>
Signed-off-by: Namrata Khake <namrata.khake@seagate.com>