### PR TITLE
[cortx-1.0] EOS 14896 Bucket name rules are inconsistent with AWS

### DIFF
--- a/gui/src/common/regex-helpers.ts
+++ b/gui/src/common/regex-helpers.ts
@@ -32,7 +32,7 @@ export const bucketNameRegex = helpers.regex(
   /^[a-z0-9][a-z0-9-.]{3,54}[a-z0-9]$/
 );
 export const bucketNameTooltipMessage = `The bucket name must be of minimum 4 characters and maximum 56 characters.
-Only lowercase, numbers, period(.) and dash (-) are allowed. The bucket name cannot start and end with a dash (-).`;
+Only lowercase, numbers, dash(-) and dot (.) are allowed. The bucket name cannot start and end with a dash (-) or dot(.).`;
 
 export const passwordRegex = helpers.regex(
   "passwordRegex",
@@ -52,11 +52,11 @@ export const commaSeparatedEmailsRegex = helpers.regex(
 
 export const udxBucketNameRegex = helpers.regex(
   "udxBucketNameRegex",
-  /^[a-z0-9-]{0,51}[a-z0-9]$/
+  /^[a-z0-9-.]{0,51}[a-z0-9]$/
 );
 // tslint:disable-next-line
 export const udxBucketNameTooltipMessage = `To identify the S3 bucket correctly, the Bucket name will always use "udx" as its prefix. The bucket name must be of minimum 5 characters and maximum 56 characters.
-  Only lowercase, numbers, and dash (-) are allowed. The bucket name cannot start and end with a dash (-).`;
+  Only lowercase, numbers, dash(-) and dot (.) are allowed. The bucket name cannot start and end with a dash (-) or dot(.).`;
 
 export const udxURLRegex = helpers.regex(
   "udxURLRegex",

--- a/gui/src/common/regex-helpers.ts
+++ b/gui/src/common/regex-helpers.ts
@@ -15,33 +15,27 @@
 * please email opensource@seagate.com or cortx-questions@seagate.com.
 */
 import { helpers } from "vuelidate/lib/validators";
+import i18n from "../i18n";
 export const accountNameRegex = helpers.regex(
   "accountNameRegex",
   /^[a-zA-Z0-9_-]{4,56}$/
 );
-export const accountNameTooltipMessage =
-  // tslint:disable-next-line: max-line-length
-  "The account name must be of minimum 4 characters and maximum 56 characters. The username must be alphanumeric and can contain underscore (_) and dash (-).";
+export const accountNameTooltipMessage = i18n.t("regex-validation.account-tooltip");
 
-export const usernameTooltipMessage =
-  // tslint:disable-next-line
-  "The username must be of minimum 4 characters and maximum 56 characters. The username must be alphanumeric and can contain underscore (_) and dash (-). The username must not be 'root' or 'Root'.";
+export const usernameTooltipMessage =  i18n.t("regex-validation.username-tooltip");
 
 export const bucketNameRegex = helpers.regex(
   "bucketNameRegex",
   /^[a-z0-9][a-z0-9-.]{3,54}[a-z0-9]$/
 );
-export const bucketNameTooltipMessage = `The bucket name must be of minimum 4 characters and maximum 56 characters.
-Only lowercase, numbers, dash(-) and dot (.) are allowed. The bucket name cannot start and end with a dash (-) or dot(.).`;
+export const bucketNameTooltipMessage = i18n.t("regex-validation.bucket-input-tooltip");
 
 export const passwordRegex = helpers.regex(
   "passwordRegex",
   // tslint:disable-next-line
   /(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#\$%\^&\*\(\)\_\+\-\=\[\]\{\}\|\'])[A-Za-z\d!@#\$%\^&\*\(\)\_\+\-\=\[\]\{\}\|\']{8,}/
 );
-export const passwordTooltipMessage =
-  // tslint:disable-next-line
-  "Password must contain: Minimum 8 characters, One uppercase letter, One lowercase letter, One special character, and One number";
+export const passwordTooltipMessage = i18n.t("regex-validation.password-tooltip");
 
 export const iamPathRegex = helpers.regex("pathRegex", /^(\/[^/ ]*)+\/?$/);
 // tslint:disable-next-line
@@ -55,8 +49,7 @@ export const udxBucketNameRegex = helpers.regex(
   /^[a-z0-9-.]{0,51}[a-z0-9]$/
 );
 // tslint:disable-next-line
-export const udxBucketNameTooltipMessage = `To identify the S3 bucket correctly, the Bucket name will always use "udx" as its prefix. The bucket name must be of minimum 5 characters and maximum 56 characters.
-  Only lowercase, numbers, dash(-) and dot (.) are allowed. The bucket name cannot start and end with a dash (-) or dot(.).`;
+export const udxBucketNameTooltipMessage = i18n.t("regex-validation.bucket-input-tooltip");
 
 export const udxURLRegex = helpers.regex(
   "udxURLRegex",

--- a/gui/src/common/regex-helpers.ts
+++ b/gui/src/common/regex-helpers.ts
@@ -29,10 +29,10 @@ export const usernameTooltipMessage =
 
 export const bucketNameRegex = helpers.regex(
   "bucketNameRegex",
-  /^[a-z0-9][a-z0-9-]{3,54}[a-z0-9]$/
+  /^[a-z0-9][a-z0-9-.]{3,54}[a-z0-9]$/
 );
 export const bucketNameTooltipMessage = `The bucket name must be of minimum 4 characters and maximum 56 characters.
-Only lowercase, numbers, and dash (-) are allowed. The bucket name cannot start and end with a dash (-).`;
+Only lowercase, numbers, period(.) and dash (-) are allowed. The bucket name cannot start and end with a dash (-).`;
 
 export const passwordRegex = helpers.regex(
   "passwordRegex",

--- a/gui/src/components/s3/account-management.vue
+++ b/gui/src/components/s3/account-management.vue
@@ -650,8 +650,8 @@ export default class CortxAccountManagement extends Vue {
   private accountsTableHeaderList: any[];
   private accountsList: Account[] = [];
   private accountToDelete: string = "";
-  private passwordTooltipMessage: string = passwordTooltipMessage;
-  private accountNameTooltipMessage: string = accountNameTooltipMessage;
+  private passwordTooltipMessage = passwordTooltipMessage;
+  private accountNameTooltipMessage = accountNameTooltipMessage;
   private isCredentialsFileDownloaded: boolean = false;
   private credentialsFileContent: string = "";
   private showEditAccountForm: boolean;

--- a/gui/src/components/s3/bucket-creation.vue
+++ b/gui/src/components/s3/bucket-creation.vue
@@ -366,7 +366,7 @@ export default class CortxBucketCreation extends Vue {
   private bucketToDelete: string = "";
   private policyJSON: any = "";
   private bucketName: any = "";
-  private bucketNameTooltipMessage: string = bucketNameTooltipMessage;
+  private bucketNameTooltipMessage = bucketNameTooltipMessage;
   private bucketUrl = "";
   private noBucketPolicy: boolean;
 
@@ -381,13 +381,13 @@ export default class CortxBucketCreation extends Vue {
     this.showBucketPolicyDialog = false;
     this.bucketsTableHeaderList = [
       {
-        text: "Name",
+        text: i18n.t("common.name"),
         value: "name",
         sortable: false
       },
-      { 
-        text: "Action", 
-        value: "data-table-expand" 
+      {
+        text: i18n.t("common.action"),
+        value: "data-table-expand"
       }
     ];
   }

--- a/gui/src/components/s3/iam-user-management.vue
+++ b/gui/src/components/s3/iam-user-management.vue
@@ -423,8 +423,8 @@ export default class CortxIAMUserManagement extends Vue {
   private usersList: IAMUser[] = [];
   private user: IAMUser;
   private userToDelete: string = "";
-  private passwordTooltipMessage: string = passwordTooltipMessage;
-  private usernameTooltipMessage: string = usernameTooltipMessage;
+  private passwordTooltipMessage = passwordTooltipMessage;
+  private usernameTooltipMessage = usernameTooltipMessage;
   private credentialsFileContent: string = "";
   private isCredentialsFileDownloaded: boolean = false;
   private selectedIAMUser: string = "";

--- a/gui/src/components/udx/cortx-udx-registration.vue
+++ b/gui/src/components/udx/cortx-udx-registration.vue
@@ -487,9 +487,9 @@ import apiRegister from "../../services/api-register";
 export default class CortxUDXRegistration extends Vue {
   public registrationToken: string = "";
   public registrationResponse: any = null;
-  public passwordTooltipMessage: string = passwordTooltipMessage;
-  public accountNameTooltipMessage: string = accountNameTooltipMessage;
-  public bucketNameTooltipMessage: string = udxBucketNameTooltipMessage;
+  public passwordTooltipMessage = passwordTooltipMessage;
+  public accountNameTooltipMessage = accountNameTooltipMessage;
+  public bucketNameTooltipMessage = udxBucketNameTooltipMessage;
   private showAccessKeyDetailsDialog: boolean;
   private accessKeyDetails: any = {};
   private accessKeyTableHeaderList: any[];

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -123,7 +123,8 @@
     "accept": "Accept",
     "email": "Email",
     "login": "Login",
-    "logout": "Logout"
+    "logout": "Logout",
+    "action": "Action"
   },
   "csmuser": {
     "user-setting-label": "User settings: Local",
@@ -511,5 +512,11 @@
   "license": {
     "header": "To set up your system, you must accept the Terms and Conditions.",
     "getStarted": "Accept Terms & Condition"
+  },
+  "regex-validation": {
+    "bucket-input-tooltip":"The bucket name must be of minimum 4 characters and maximum 56 characters. Only lowercase, numbers, dash(-) and dot (.) are allowed. The bucket name cannot start and end with a dash (-) or dot(.)." ,
+    "account-tooltip":"The account name must be of minimum 4 characters and maximum 56 characters. The username must be alphanumeric and can contain underscore (_) and dash (-).",
+    "username-tooltip": "The username must be of minimum 4 characters and maximum 56 characters. The username must be alphanumeric and can contain underscore (_) and dash (-). The username must not be 'root' or 'Root'.",
+    "password-tooltip": "Password must contain: Minimum 8 characters, One uppercase letter, One lowercase letter, One special character, and One number"
   }
 }


### PR DESCRIPTION
# Front-end 

## Problem Statement
<pre>
  <code>
Story Ref (if any): EOS-14896 Bucket name rules are inconsistent with AWS
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
 NOT Required
  </code>
</pre>
## Problem Description
<pre>
  <code>
   Bucket name input doesn't allow to add '.'in the name
  </code>
</pre>
## Solution
<pre>
  <code>
- Updated regex for the bucketname input
- Updated message for bucket name input tooltip

  </code>
</pre>
![image](https://user-images.githubusercontent.com/64768901/98213315-e4c45a80-1f6a-11eb-8213-8210b283950a.png)
![image](https://user-images.githubusercontent.com/64768901/98213375-fe65a200-1f6a-11eb-8f4c-f1f9607c8e3b.png)
![image](https://user-images.githubusercontent.com/64768901/98216593-42f33c80-1f6f-11eb-9b02-8e6b8965c850.png)
![image](https://user-images.githubusercontent.com/64768901/98216849-a54c3d00-1f6f-11eb-880d-421c9d0ff429.png)
![image](https://user-images.githubusercontent.com/64768901/98233921-abe5af00-1f85-11eb-823e-2b96c24dc440.png)
![image](https://user-images.githubusercontent.com/64768901/98233953-b9029e00-1f85-11eb-9636-32803e7342a0.png)
![image](https://user-images.githubusercontent.com/64768901/98234011-d7689980-1f85-11eb-81a7-3c9addb14bd3.png)
![image](https://user-images.githubusercontent.com/64768901/98234109-f7985880-1f85-11eb-885e-2982bc19cfdc.png)




## Unit Test Cases
<pre>
  <code>
- Done with locally
  </code>
</pre>
Signed-off-by: Namrata Khake <namrata.khake@seagate.com>