### PR TITLE
[cortx1.0-dev] EOS-15040: REST : Complete node details are missing in the GET system health /api/v1/system/health/node?node_id=node:sm8-r19.pun.seagate.com response

### DIFF
--- a/web/src/config/client_swagger.json
+++ b/web/src/config/client_swagger.json
@@ -1811,12 +1811,6 @@
 					"application/json": {}
 				},
 				"parameters": [{
-					"name": "node_id",
-					"in": "query",
-					"description": "Specifies the node id",
-					"required": false,
-					"type": "string"
-				}, {
 					"name": "authorization",
 					"in": "header",
 					"required": true,
@@ -1824,13 +1818,13 @@
 				}]
 			}
 		},
-		"/system/health/view": {
+		"/system/health/components": {
 			"get": {
 				"tags": ["Health"],
-				"summary": "Get Health of nodes with alerts: Accessible to CSM users having monitor and manage permissions",
+				"summary": "Get components of nodes and their health: Accessible to CSM users having monitor and manage permissions",
 				"responses": {
 					"200": {
-						"description": "OK"
+						"description": "OK: Health of the nodes fetched successfully."
 					},
 					"400": {
 						"description": "Bad Request: when an invalid response message is received for any of the cli commands."
@@ -1898,14 +1892,14 @@
 					{
 						"name": "component_id",
 						"in": "query",
-						"description": "Specifies the node id",
+						"description": "Specifies the component id",
 						"required": false,
 						"type": "string"
 					},
 					{
 						"name": "severity",
 						"in": "query",
-						"description": "Specifies the node id",
+						"description": "Specifies the severity",
 						"required": false,
 						"enum": [
 							"ok",

--- a/web/src/config/swagger.json
+++ b/web/src/config/swagger.json
@@ -2470,37 +2470,19 @@
 				"summary": "Get Health Summary of the system: Accessible to CSM users having monitor and manage permissions",
 				"responses": {
 					"200": {
-						"description": "OK"
-					},
-					"201": {
-						"description": "No Content"
+						"description": "OK: Health Summary of the system fetched successfully."
 					},
 					"400": {
-						"description": "Bad Request"
+						"description": "Bad Request: when an invalid response message is received for any of the cli commands."
 					},
 					"401": {
-						"description": "Unauthorized"
-					},
-					"403": {
-						"description": "Forbidden"
-					},
-					"404": {
-						"description": "No Data Found"
-					},
-					"409": {
-						"description": "Conflict"
-					},
-					"422": {
-						"description": "Unprocessable Entity"
+						"description": "Unauthorized: Token has not found or invalid format or session is invalid"
 					},
 					"499": {
-						"description": "Call Cancelled"
+						"description": "Call Cancelled: Call cancelled by client."
 					},
 					"500": {
-						"description": "Internal Server Error"
-					},
-					"501": {
-						"description": "Not Implemented"
+						"description": "Internal Server Error: When requested resource is not available."
 					}
 				},
 				"content": {
@@ -2520,49 +2502,28 @@
 				"summary": "Get Health of nodes: Accessible to CSM users having monitor and manage permissions",
 				"responses": {
 					"200": {
-						"description": "OK"
-					},
-					"201": {
-						"description": "No Content"
+						"description": "OK: Health of the nodes fetched successfully."
 					},
 					"400": {
-						"description": "Bad Request"
+						"description": "Bad Request: when an invalid response message is received for any of the cli commands."
 					},
 					"401": {
-						"description": "Unauthorized"
+						"description": "Unauthorized: Token has not found or invalid format or session is invalid"
 					},
 					"403": {
-						"description": "Forbidden"
-					},
-					"404": {
-						"description": "No Data Found"
-					},
-					"409": {
-						"description": "Conflict"
-					},
-					"422": {
-						"description": "Unprocessable Entity"
+						"description": "Forbidden: This error is raised for all cases when user don't have permissions"
 					},
 					"499": {
-						"description": "Call Cancelled"
+						"description": "Call Cancelled: Call cancelled by client."
 					},
 					"500": {
-						"description": "Internal Server Error"
-					},
-					"501": {
-						"description": "Not Implemented"
+						"description": "Internal Server Error: When requested resource is not available."
 					}
 				},
 				"content": {
 					"application/json": {}
 				},
 				"parameters": [{
-					"name": "node_id",
-					"in": "query",
-					"description": "Specifies the node id",
-					"required": false,
-					"type": "string"
-				}, {
 					"name": "authorization",
 					"in": "header",
 					"required": true,
@@ -2570,43 +2531,28 @@
 				}]
 			}
 		},
-		"/system/health/view": {
+		"/system/health/components": {
 			"get": {
 				"tags": ["Health"],
-				"summary": "Get Health of nodes with alerts: Accessible to CSM users having monitor and manage permissions",
+				"summary": "Get components of nodes and their health: Accessible to CSM users having monitor and manage permissions",
 				"responses": {
 					"200": {
-						"description": "OK"
-					},
-					"201": {
-						"description": "No Content"
+						"description": "OK: Health of the nodes fetched successfully."
 					},
 					"400": {
-						"description": "Bad Request"
+						"description": "Bad Request: when an invalid response message is received for any of the cli commands."
 					},
 					"401": {
-						"description": "Unauthorized"
+						"description": "Unauthorized: Token has not found or invalid format or session is invalid"
 					},
 					"403": {
-						"description": "Forbidden"
-					},
-					"404": {
-						"description": "No Data Found"
-					},
-					"409": {
-						"description": "Conflict"
-					},
-					"422": {
-						"description": "Unprocessable Entity"
+						"description": "Forbidden: This error is raised for all cases when user don't have permissions"
 					},
 					"499": {
-						"description": "Call Cancelled"
+						"description": "Call Cancelled: Call cancelled by client."
 					},
 					"500": {
-						"description": "Internal Server Error"
-					},
-					"501": {
-						"description": "Not Implemented"
+						"description": "Internal Server Error: When requested resource is not available."
 					}
 				},
 				"content": {
@@ -2634,37 +2580,22 @@
 				"summary": "Get Health of resources with severity: Accessible to CSM users having monitor and manage permissions",
 				"responses": {
 					"200": {
-						"description": "OK"
-					},
-					"201": {
-						"description": "No Content"
+						"description": "OK: resource health fetched successfully."
 					},
 					"400": {
-						"description": "Bad Request"
+						"description": "Bad Request: when an invalid response message is received for any of the cli commands."
 					},
 					"401": {
-						"description": "Unauthorized"
+						"description": "Unauthorized: Token has not found or invalid format or session is invalid"
 					},
 					"403": {
-						"description": "Forbidden"
-					},
-					"404": {
-						"description": "No Data Found"
-					},
-					"409": {
-						"description": "Conflict"
-					},
-					"422": {
-						"description": "Unprocessable Entity"
+						"description": "Forbidden: This error is raised for all cases when user don't have permissions"
 					},
 					"499": {
-						"description": "Call Cancelled"
+						"description": "Call Cancelled: Call cancelled by client."
 					},
 					"500": {
-						"description": "Internal Server Error"
-					},
-					"501": {
-						"description": "Not Implemented"
+						"description": "Internal Server Error: When requested resource is not available."
 					}
 				},
 				"content": {
@@ -2674,14 +2605,14 @@
 					{
 						"name": "component_id",
 						"in": "query",
-						"description": "Specifies the node id",
+						"description": "Specifies the component id",
 						"required": false,
 						"type": "string"
 					},
 					{
 						"name": "severity",
 						"in": "query",
-						"description": "Specifies the node id",
+						"description": "Specifies the severity",
 						"required": false,
 						"enum": [
 							"ok",


### PR DESCRIPTION
# Front-end 

## Problem Statement
<pre>
  <code>
Story Ref (if any): EOS-15040: REST : Complete node details are missing in the GET system health /api/v1/system/health/node?node_id=node:sm8-r19.pun.seagate.com response
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
 NOT Required
  </code>
</pre>
## Problem Description
<pre>
  <code>
  Rest APIs are not updated in swagger
  </code>
</pre>
## Solution
<pre>
  <code>
- Removed node_id parameter from /system/health/node
- Removed /system/health/view API as it is not used
- Added /system/health/components API
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
- Done with locally
  </code>
</pre>
Signed-off-by: Soniya Moholkar