### PR TITLE
[Cortx-1.0] EOS-15330-fixed header login name issue

### DIFF
--- a/gui/src/components/header/header-bar.vue
+++ b/gui/src/components/header/header-bar.vue
@@ -130,6 +130,7 @@ export default class HeaderBar extends Vue {
   line-height: 20px;
   text-align: center;
   color: #ffffff;
+  white-space: nowrap;
 }
 .cortx-header-right-aligned-items {
   margin-left: auto;


### PR DESCRIPTION
# Front-end 

## Problem Statement
<pre>
  <code>
Story Ref (if any): EOS-15330 (CSM: In CSM GUI, for s3 login, username does not appear clearly, its seen half)
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
 NOT Required
  </code>
</pre>
## Problem Description
<pre>
  <code>
  Login name is not seen properly in header bar
  </code>
</pre>
## Solution
<pre>
  <code>
  </code>
</pre>
![image](https://user-images.githubusercontent.com/64768901/100577049-5f339080-3305-11eb-8b0b-229e3ae0d5bd.png)
![image](https://user-images.githubusercontent.com/64768901/100577715-c7cf3d00-3306-11eb-8ce1-f1da1707984e.png)


JIRA ID | EOS-15330:  https://jts.seagate.com/browse/EOS-15330
-- | --
GA Required | Yes
Solution Summary | As, the text has the hypan/dash the text was breaking and added with new line. To resolve this issue added css proprty  white-space: nowrap;
Impact | Now login name can see properly in header without breaking text
PR | https://github.com/Seagate/cortx-management-portal/pull/229



## Unit Test Cases
<pre>
  <code>
- NOT required
  </code>
</pre>

Signed-off-by: Namrata Khake <namrata.khake@seagate.com>
Signed-off-by: Namrata Khake <namrata.khake@seagate.com>