### PR TITLE
Replace UDX with LDP and add expansion to summary page

### DIFF
--- a/gui/src/components/udx/cortx-udx-details.vue
+++ b/gui/src/components/udx/cortx-udx-details.vue
@@ -17,7 +17,7 @@
 <template>
   <div>
     <div class="udx-page-title">
-      <label class="cortx-text-lg cortx-text-bold">{{ $t("settings.UDX") }}</label>
+      <label class="cortx-text-lg cortx-text-bold">{{ $t("settings.ldp") }}</label>
     </div>
     <div class="mt-2">
       <div id="udx-device-details-container" v-if="udx">

--- a/gui/src/components/udx/cortx-udx-registration.vue
+++ b/gui/src/components/udx/cortx-udx-registration.vue
@@ -115,12 +115,12 @@
               <v-expansion-panels class="mt-2 mb-5">
                 <v-expansion-panel>
                   <v-expansion-panel-header class="cortx-text-lg font-weight-bold">
-                    {{ $t("udx-registration.account-details") }}
+                    {{ $t("udx-registration.account_details") }}
                   </v-expansion-panel-header>
                   <v-expansion-panel-content>
-                    <div>{{ $t("udx-registration.S3Account") }}: {{ registrationForm.accountName || $t("common.not-available") }}</div>
-                    <div>{{ $t("udx-registration.IAMUser") }}: {{ registrationForm.iamUsername || $t("common.not-available") }}</div>
-                    <div>{{ $t("udx-registration.bucketName") }}: {{ registrationForm.bucketName || $t("common.not-available") }}</div>
+                    <div>{{ $t("udx-registration.S3Account") }}: {{ registrationForm.accountName || $t("common.not_available") }}</div>
+                    <div>{{ $t("udx-registration.IAMUser") }}: {{ registrationForm.iamUsername || $t("common.not_available") }}</div>
+                    <div>{{ $t("udx-registration.bucketName") }}: {{ registrationForm.bucketName || $t("common.not_available") }}</div>
                   </v-expansion-panel-content>
                 </v-expansion-panel>
               </v-expansion-panels>
@@ -140,7 +140,7 @@
                     for="url"
                     id="udx-url-label"
                   >
-                  {{ $t("udx-registration.url") }}*: {{ registrationForm.url || $t("common.not-available") }}
+                  {{ $t("udx-registration.url") }}*: {{ registrationForm.url || $t("common.not_available") }}
                   </label>
                   <input
                     v-if="hideInput"

--- a/gui/src/components/udx/cortx-udx-registration.vue
+++ b/gui/src/components/udx/cortx-udx-registration.vue
@@ -115,7 +115,7 @@
               <v-expansion-panels class="mt-2 mb-5">
                 <v-expansion-panel>
                   <v-expansion-panel-header class="cortx-text-lg font-weight-bold">
-                    {{ $t("udx-registration.accountDetails") }}
+                    {{ $t("udx-registration.account-details") }}
                   </v-expansion-panel-header>
                   <v-expansion-panel-content>
                     <div>{{ $t("udx-registration.S3Account") }}: {{ registrationForm.accountName || $t("common.NA") }}</div>

--- a/gui/src/components/udx/cortx-udx-registration.vue
+++ b/gui/src/components/udx/cortx-udx-registration.vue
@@ -111,14 +111,22 @@
           </v-row>
 
           <v-row>
-            <v-col class="py-0 pr-0">
-              <br />
-              <h4>{{ $t("udx-registration.S3Account") }}: {{ registrationForm.accountName }}</h4>
-              <h4>{{ $t("udx-registration.IAMUser") }}: {{ registrationForm.iamUsername }}</h4>
-              <h4>{{ $t("udx-registration.bucketName") }}: {{ `ldp-${registrationForm.bucketName}` }}</h4>
-              <br />
+            <v-col class="p-0" md="4">
+              <v-expansion-panels class="mt-2 mb-5">
+                <v-expansion-panel>
+                  <v-expansion-panel-header class="cortx-text-lg font-weight-bold">
+                    {{ $t("udx-registration.accountDetails") }}
+                  </v-expansion-panel-header>
+                  <v-expansion-panel-content>
+                    <div>{{ $t("udx-registration.S3Account") }}: {{ registrationForm.accountName || $t("common.NA") }}</div>
+                    <div>{{ $t("udx-registration.IAMUser") }}: {{ registrationForm.iamUsername || $t("common.NA") }}</div>
+                    <div>{{ $t("udx-registration.bucketName") }}: {{ registrationForm.bucketName || $t("common.NA") }}</div>
+                  </v-expansion-panel-content>
+                </v-expansion-panel>
+              </v-expansion-panels>
             </v-col>
           </v-row>
+
           <form autocomplete="off" id="create-new-lyvepilot">
             <v-row>
                <v-col class="py-0 pr-0">
@@ -132,7 +140,7 @@
                     for="url"
                     id="udx-url-label"
                   >
-                  URL* : {{ registrationForm.url }}
+                  {{ $t("udx-registration.url") }}*: {{ registrationForm.url || $t("common.NA") }}
                   </label>
                   <input
                     v-if="hideInput"
@@ -365,7 +373,7 @@ export default class CortxUDXRegistration extends Vue {
         auth_token: this.authToken
       }
     };
-    this.$store.dispatch("systemConfig/showLoader", "Registering UDX...");
+    this.$store.dispatch("systemConfig/showLoader", "Registering LDP...");
     const payload = {
       registerDeviceParams: {
         url: this.registrationForm.url,

--- a/gui/src/components/udx/cortx-udx-registration.vue
+++ b/gui/src/components/udx/cortx-udx-registration.vue
@@ -111,19 +111,12 @@
           </v-row>
 
           <v-row>
-            <v-col class="p-0" md="4">
-              <v-expansion-panels class="mt-2 mb-5">
-                <v-expansion-panel>
-                  <v-expansion-panel-header class="cortx-text-lg font-weight-bold">
-                    {{ $t("udx-registration.account_details") }}
-                  </v-expansion-panel-header>
-                  <v-expansion-panel-content>
-                    <div>{{ $t("udx-registration.S3Account") }}: {{ registrationForm.accountName || $t("common.not_available") }}</div>
-                    <div>{{ $t("udx-registration.IAMUser") }}: {{ registrationForm.iamUsername || $t("common.not_available") }}</div>
-                    <div>{{ $t("udx-registration.bucketName") }}: {{ registrationForm.bucketName || $t("common.not_available") }}</div>
-                  </v-expansion-panel-content>
-                </v-expansion-panel>
-              </v-expansion-panels>
+            <v-col class="py-0 pr-0">
+              <br />
+              <h4>{{ $t("udx-registration.S3Account") }}: {{ registrationForm.accountName }}</h4>
+              <h4>{{ $t("udx-registration.IAMUser") }}: {{ registrationForm.iamUsername }}</h4>
+              <h4>{{ $t("udx-registration.bucketName") }}: {{ `ldp-${registrationForm.bucketName}` }}</h4>
+              <br />
             </v-col>
           </v-row>
 
@@ -140,7 +133,7 @@
                     for="url"
                     id="udx-url-label"
                   >
-                  {{ $t("udx-registration.url") }}*: {{ registrationForm.url || $t("common.not_available") }}
+                  {{ $t("udx-registration.url") }}*: {{ registrationForm.url }}
                   </label>
                   <input
                     v-if="hideInput"
@@ -373,7 +366,7 @@ export default class CortxUDXRegistration extends Vue {
         auth_token: this.authToken
       }
     };
-    this.$store.dispatch("systemConfig/showLoader", "Registering LDP...");
+    this.$store.dispatch("systemConfig/showLoader", i18n.t("udx-registration.registeringLDP"));
     const payload = {
       registerDeviceParams: {
         url: this.registrationForm.url,

--- a/gui/src/components/udx/cortx-udx-registration.vue
+++ b/gui/src/components/udx/cortx-udx-registration.vue
@@ -118,9 +118,9 @@
                     {{ $t("udx-registration.account-details") }}
                   </v-expansion-panel-header>
                   <v-expansion-panel-content>
-                    <div>{{ $t("udx-registration.S3Account") }}: {{ registrationForm.accountName || $t("common.NA") }}</div>
-                    <div>{{ $t("udx-registration.IAMUser") }}: {{ registrationForm.iamUsername || $t("common.NA") }}</div>
-                    <div>{{ $t("udx-registration.bucketName") }}: {{ registrationForm.bucketName || $t("common.NA") }}</div>
+                    <div>{{ $t("udx-registration.S3Account") }}: {{ registrationForm.accountName || $t("common.not-available") }}</div>
+                    <div>{{ $t("udx-registration.IAMUser") }}: {{ registrationForm.iamUsername || $t("common.not-available") }}</div>
+                    <div>{{ $t("udx-registration.bucketName") }}: {{ registrationForm.bucketName || $t("common.not-available") }}</div>
                   </v-expansion-panel-content>
                 </v-expansion-panel>
               </v-expansion-panels>
@@ -140,7 +140,7 @@
                     for="url"
                     id="udx-url-label"
                   >
-                  {{ $t("udx-registration.url") }}*: {{ registrationForm.url || $t("common.NA") }}
+                  {{ $t("udx-registration.url") }}*: {{ registrationForm.url || $t("common.not-available") }}
                   </label>
                   <input
                     v-if="hideInput"

--- a/gui/src/components/udx/cortx-udx.vue
+++ b/gui/src/components/udx/cortx-udx.vue
@@ -28,6 +28,7 @@ import { Api } from "../../services/api";
 import apiRegister from "../../services/api-register";
 import CortxUDXDetails from "./cortx-udx-details.vue";
 import CortxUDXRegistration from "./cortx-udx-registration.vue";
+import i18n from "./../../i18n";
 
 @Component({
   name: "cortx-udx",
@@ -48,7 +49,7 @@ export default class CortxUDX extends Vue {
   }
 
   public async getUDXDetails() {
-    this.$store.dispatch("systemConfig/showLoader", "Fetching LDP details...");
+    this.$store.dispatch("systemConfig/showLoader", i18n.t("udx-registration.fetchingLDP"));
     const res = await Api.getAll(apiRegister.udx_device);
     if (res && res.data && res.data.length > 0) {
       this.udx = res.data[0];

--- a/gui/src/components/udx/cortx-udx.vue
+++ b/gui/src/components/udx/cortx-udx.vue
@@ -48,7 +48,7 @@ export default class CortxUDX extends Vue {
   }
 
   public async getUDXDetails() {
-    this.$store.dispatch("systemConfig/showLoader", "Fetching UDX details...");
+    this.$store.dispatch("systemConfig/showLoader", "Fetching LDP details...");
     const res = await Api.getAll(apiRegister.udx_device);
     if (res && res.data && res.data.length > 0) {
       this.udx = res.data[0];

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -126,7 +126,7 @@
         "login": "Login",
         "logout": "Logout",
         "continue": "Continue",
-        "NA": "NA"
+        "not-available": "NA"
     },
     "csmuser": {
         "user-setting-label": "User settings: Local",

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -195,7 +195,7 @@
         "udx-url-required": "URL is required",
         "invalid-url": "Invalid URL",
         "s3-details": "S3 Account details",
-        "accountDetails": "Account details",
+        "account-details": "Account details",
         "url": "URL",
         "accountname-required": "Account name is required",
         "invalid-name": "Invalid account name",

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -125,7 +125,8 @@
         "email": "Email",
         "login": "Login",
         "logout": "Logout",
-        "continue": "Continue"
+        "continue": "Continue",
+        "NA": "NA"
     },
     "csmuser": {
         "user-setting-label": "User settings: Local",
@@ -194,6 +195,8 @@
         "udx-url-required": "URL is required",
         "invalid-url": "Invalid URL",
         "s3-details": "S3 Account details",
+        "accountDetails": "Account details",
+        "url": "URL",
         "accountname-required": "Account name is required",
         "invalid-name": "Invalid account name",
         "email": "Email id*",
@@ -222,7 +225,6 @@
         "userAlreadyExist": "User already Exist with",
         "createNewBucket": "Create new Bucket",
         "noBucketFound": "No Bucket found. Please proceed by creating a new bucket.",
-        "ldp": "ldp-",
         "S3Account": "S3 Account",
         "IAMUser": "IAM User",
         "bucketName": "Bucket Name",
@@ -515,7 +517,7 @@
         "NTPSettings": "Network time protocol (NTP) settings",
         "SSLCertificateUpload": "SSL certificate upload",
         "SSLCertificateUploadMsg": "By default, the system uses the SSL certificate provided by Seagate. To use a different SSL certificate, click Choose File to browse and select the appropriate SSL Certificate file. Click Upload certificate to upload the selected SSL certificate.",
-        "UDX": "UDX",
+        "ldp": "LDP",
         "name": "Name",
         "productID": "Product ID",
         "serialNumber": "Serial number",

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -126,7 +126,7 @@
         "login": "Login",
         "logout": "Logout",
         "continue": "Continue",
-        "not-available": "NA"
+        "not_available": "NA"
     },
     "csmuser": {
         "user-setting-label": "User settings: Local",
@@ -195,7 +195,7 @@
         "udx-url-required": "URL is required",
         "invalid-url": "Invalid URL",
         "s3-details": "S3 Account details",
-        "account-details": "Account details",
+        "account_details": "Account details",
         "url": "URL",
         "accountname-required": "Account name is required",
         "invalid-name": "Invalid account name",

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -125,8 +125,7 @@
         "email": "Email",
         "login": "Login",
         "logout": "Logout",
-        "continue": "Continue",
-        "not_available": "NA"
+        "continue": "Continue"
     },
     "csmuser": {
         "user-setting-label": "User settings: Local",
@@ -195,7 +194,6 @@
         "udx-url-required": "URL is required",
         "invalid-url": "Invalid URL",
         "s3-details": "S3 Account details",
-        "account_details": "Account details",
         "url": "URL",
         "accountname-required": "Account name is required",
         "invalid-name": "Invalid account name",
@@ -241,7 +239,9 @@
         "onYourLyvePilot": "On your Lyve Pilot web portal choose 'Add Device' and then enter the identification token below.",
         "accountName": "Account name",
         "selectBucket": "Select Bucket",
-        "account": "Account"
+        "account": "Account",
+        "registeringLDP": "Registering LDP...",
+        "fetchingLDP": "Fetching LDP details..."
     },
     "aboutUs": {
         "title": "About",


### PR DESCRIPTION
# Front-end 

## Problem Statement
<pre>
  <code>
Story Ref (if any): EOS-15339: CSM: GUI needs to have Lyve Pilot instead of UDX in LyvePilot tab. Bucket name should not have ldp at the beginning
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
 NOT Required
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Need to remove all terms and text related to UDX and add expansion panel on sumary page
  </code>
</pre>
## Solution
<pre>
  <code>
Replace UDX with LDP and add expansion to summary page
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
- NOT required
  </code>
</pre>

![image](https://user-images.githubusercontent.com/64767189/100582765-c35b5200-330f-11eb-8cab-f48454ab7a9f.png)
