### PR TITLE
[main]EOS-17346: Unable to login to CSM GUI with existing credentials.

### DIFF
--- a/web/src/services/websocket/socket-service.ts
+++ b/web/src/services/websocket/socket-service.ts
@@ -48,6 +48,10 @@ export class SocketService {
             wslistener.onerror = function (err: any) {
                 console.log("TCL: SocketService -> wslistener.onerror -> err", err);
             }
+            ws.onclose = (closeEvent: any) => {
+                console.log("logger: WebSocket connection closed");
+                wslistener.close();
+            };
         });
     }
 }


### PR DESCRIPTION
# UI

## Problem Statement
<pre>
  <code>User not able to login after the system is under continuous small/moderate load
from third party application from last 9-10 days.
  </code>
</pre>

## Problem Description
<pre>
  <code>
- The issue is due to file descriptors. Process has opened too many files (file descriptors) and cannot open new ones. The open file limit for a current user is 1024.
- This is due to dangling websocket connections between csm_web and csm_agent that do not get closed
  </code>
</pre>

## Solution
<pre>
  <code>
- The solution is to explicitly close the connections when the client (gui) socket connection is closed. 
  </code>
</pre>

## Test cases
<pre>
  <code>
- Tested by reloading the ui page and checking if the existing socket connection between web and agent gets closed and new connection is created. 
  </code>
</pre>

## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>

Signed-off-by: Shri Metta <shri.metta@seagate.com>