### PR TITLE
EOS-15327: Fixed layout issue in dropdown menu

### DIFF
--- a/gui/src/components/widgets/dropdown/cortx-dropdown-view.vue
+++ b/gui/src/components/widgets/dropdown/cortx-dropdown-view.vue
@@ -94,7 +94,7 @@ export default class CortxDropdown extends Vue {
   font: inherit;
 }
 .cortx-dropdown-menu {
-  position: fixed;
+  position: absolute;
   background: #ffffff;
   width: inherit;
   max-height: 188px;


### PR DESCRIPTION
# UI

 

CSM UI : Pop-up for 'Protocol' Notifications:email misaligned

 

## Problem Statement
<pre>
<code>
Story Ref (if any):EOS-15327:CSM-UI: Pop-up for 'Protocol' Notifications:email misaligned
</code>
</pre>
## Unit testing on RPM done
<pre>
<code>
No
</code>
</pre>
## Problem Description
<pre>
<code>
Dropdown menu doesn't stick to the dropdown field when scrolled. 
</code>
</pre>
## Solution/Screenshots
![image](https://user-images.githubusercontent.com/52106625/109796564-5329d880-7c3e-11eb-95ff-bd861a8f036f.png)


<pre>
<code>
</code>
</pre>
## Unit Test Cases
<pre>
<code>
1) There was a CSS issue. I changed the position value to 'absolute' in the main dropdown component.
2) After the change, it was working as expected.
3) I checked other screens that have dropdown lists for similar issue. Everything seemed to be working fine.
</code>
</pre>