### PR TITLE
EOS 18713 Reset password success message correction and removing get csm users call from S3

### DIFF
--- a/gui/src/components/s3/account-management.vue
+++ b/gui/src/components/s3/account-management.vue
@@ -860,7 +860,7 @@ export default class CortxAccountManagement extends Vue {
     };
   }
   public async mounted() {
-    this.checkPermissions();
+    await this.checkPermissions();
     await this.getAllAccounts();
   }
 
@@ -877,16 +877,16 @@ export default class CortxAccountManagement extends Vue {
   }
 
   public async checkPermissions() {    
-    const routerApp: any = this;
-    if (routerApp.$hasAccessToCsm(userPermissions.s3accounts + userPermissions.delete)) {
+    const vueInstance: any = this;
+    if (vueInstance.$hasAccessToCsm(userPermissions.s3accounts + userPermissions.delete)) {
       this.isDeleteAccountAllowed = true;
     }
-    if (routerApp.$hasAccessToCsm(userPermissions.users + userPermissions.list)) {
+    if (vueInstance.$hasAccessToCsm(userPermissions.users + userPermissions.list)) {
       const cms_res = await Api.getAll(apiRegister.csm_user + "/" + this.loggedInUserName);
       if (cms_res && cms_res.data) {
         this.isResetPasswordAllowed = cms_res.data.roles.includes("admin") || cms_res.data.roles.includes("manage");
       }
-    } else if (routerApp.$hasAccessToCsm(userPermissions.s3accounts + userPermissions.update)) {
+    } else if (vueInstance.$hasAccessToCsm(userPermissions.s3accounts + userPermissions.update)) {
       this.isUpdatePasswordAllowed = true;
     }
   }

--- a/gui/src/components/s3/account-management.vue
+++ b/gui/src/components/s3/account-management.vue
@@ -1025,7 +1025,7 @@ export default class CortxAccountManagement extends Vue {
     this.closeResetPasswordForm();
     this.$store.dispatch("systemConfig/hideLoader");
     this.successMessage = `${this.$t("s3.account.password-reset-message")} ${
-      res.data.user_name
+      res.data.account_name
     }`;
     this.showSuccessDialog = true;
   }

--- a/gui/src/components/s3/account-management.vue
+++ b/gui/src/components/s3/account-management.vue
@@ -1025,7 +1025,7 @@ export default class CortxAccountManagement extends Vue {
     this.closeResetPasswordForm();
     this.$store.dispatch("systemConfig/hideLoader");
     this.successMessage = `${this.$t("s3.account.password-reset-message")} ${
-      res.data.account_name
+      res.data.user_name
     }`;
     this.showSuccessDialog = true;
   }

--- a/gui/src/components/s3/account-management.vue
+++ b/gui/src/components/s3/account-management.vue
@@ -865,12 +865,12 @@ export default class CortxAccountManagement extends Vue {
     this.accountsList = res && res.data ? res.data.s3_accounts : [];
     this.s3Url = res.data && res.data.s3_urls ? res.data.s3_urls : [];
     this.isS3UrlNone = this.s3Url.length === 0;
-
-    const cms_res = await Api.getAll(apiRegister.csm_user);
-    if (cms_res && cms_res.data && cms_res.data.users) {
-      this.userData = cms_res.data.users;
+    if (!(this.$route.name === "s3")) {
+      const cms_res = await Api.getAll(apiRegister.csm_user);
+      if (cms_res && cms_res.data && cms_res.data.users) {
+        this.userData = cms_res.data.users;
+      }
     }
-
     this.isLoggedInUserAdminOrManage();
     this.$store.dispatch("systemConfig/hideLoader");
   }

--- a/gui/src/components/s3/iam-user-management.vue
+++ b/gui/src/components/s3/iam-user-management.vue
@@ -88,33 +88,40 @@
                   {{ props.item.arn }}
                 </td>
                 <td>
-                  <cortx-has-access
-                    :to="
-                      $cortxUserPermissions.s3iamusers +
-                      $cortxUserPermissions.delete
-                    "
-                  >
-                    <img
-                      id="iam-delete-user"
-                      @click="openConfirmDeleteDialog(props.item.user_name)"
-                      class="cortx-cursor-pointer"
-                      src="./../../assets/actions/delete-green.svg"
-                    />
-                    <v-tooltip right max-width="300">
-                      <template v-slot:activator="{ on }">
-                        <img
-                          id="iam-reset-password"
-                          v-on:click="onResetBtnClick(props.item.user_name)"
-                          v-on="on"
-                          class="cortx-cursor-pointer"
-                          src="@/assets/actions/edit-green.svg"
-                        />
-                      </template>
-                      <span id="reset-password-tooltip">
-                        {{ $t("s3.account.reset-password") }}
-                      </span>
-                    </v-tooltip>
-                  </cortx-has-access>
+                  <div v-if="isDeleteAccountAllowed">
+                    <div class="cortx-float-l cortx-margin-r">
+                      <v-tooltip right max-width="300">
+                        <template v-slot:activator="{ on }">
+                          <img
+                            id="iam-delete-user"
+                            v-on:click="openConfirmDeleteDialog(props.item.user_name)"
+                            v-on="on"
+                            class="cortx-cursor-pointer"
+                            src="./../../assets/actions/delete-green.svg"
+                          />
+                        </template>
+                        <span id="delete-account-tooltip">
+                          {{ $t("s3.account.delete-account") }}
+                        </span>
+                      </v-tooltip>
+                    </div>
+                    <div class="cortx-float-l">
+                      <v-tooltip right max-width="300">
+                        <template v-slot:activator="{ on }">
+                          <img
+                            id="iam-reset-password"
+                            v-on:click="onResetBtnClick(props.item.user_name)"
+                            v-on="on"
+                            class="cortx-cursor-pointer"
+                            src="@/assets/actions/edit-green.svg"
+                          />
+                        </template>
+                        <span id="reset-password-tooltip">
+                          {{ $t("s3.account.reset-password") }}
+                        </span>
+                      </v-tooltip>
+                    </div>
+                  </div>
                 </td>
               </tr>
             </template>
@@ -534,6 +541,7 @@ import {
   iamUsernameTooltipMessage
 } from "./../../common/regex-helpers";
 import i18n from "./s3.json";
+import { userPermissions } from "../../common/user-permissions-map"
 
 @Component({
   name: "cortx-iam-user-management",
@@ -596,6 +604,7 @@ export default class CortxIAMUserManagement extends Vue {
   private showSuccessDialog: boolean = false;
   private successMessage: string = "";
   private isS3UrlNone: boolean = true;
+  private isDeleteAccountAllowed: boolean = false;
 
   constructor() {
     super();
@@ -628,7 +637,8 @@ export default class CortxIAMUserManagement extends Vue {
     this.user = {} as IAMUser;
   }
 
-  public async mounted() {
+  public async mounted() {    
+    this.checkPermissions();
     await this.getAllUsers();
   }
 
@@ -645,6 +655,13 @@ export default class CortxIAMUserManagement extends Vue {
       ? this.usersList[0].user_name
       : "";
     this.$store.dispatch("systemConfig/hideLoader");
+  }
+
+  public async checkPermissions() {
+    const routerApp: any = this;
+    if (routerApp.$hasAccessToCsm(userPermissions.s3accounts + userPermissions.delete)) {
+      this.isDeleteAccountAllowed = true;
+    }
   }
 
   public async createUser() {
@@ -806,5 +823,8 @@ export default class CortxIAMUserManagement extends Vue {
   display: inline-block;
   padding-top: 10px;
   color: #ffffff;
+}
+.cortx-margin-r {
+  margin-right: 10px;
 }
 </style>

--- a/gui/src/components/s3/iam-user-management.vue
+++ b/gui/src/components/s3/iam-user-management.vue
@@ -771,7 +771,7 @@ export default class CortxIAMUserManagement extends Vue {
     this.closeResetPasswordForm();
     this.$store.dispatch("systemConfig/hideLoader");
     this.successMessage = `${this.$t("s3.account.password-reset-message")} ${
-      res.data.account_name
+      res.data.user_name
     }`;
     this.showSuccessDialog = true;
   }

--- a/gui/src/components/s3/iam-user-management.vue
+++ b/gui/src/components/s3/iam-user-management.vue
@@ -757,6 +757,7 @@ export default class CortxIAMUserManagement extends Vue {
 
   public async resetPassword() {
     const updateDetails = {
+      user_name: this.resetAccoutName,
       password: this.resetAccountForm.password
     };
     this.$store.dispatch(

--- a/gui/src/components/s3/iam-user-management.vue
+++ b/gui/src/components/s3/iam-user-management.vue
@@ -638,7 +638,7 @@ export default class CortxIAMUserManagement extends Vue {
   }
 
   public async mounted() {    
-    this.checkPermissions();
+    await this.checkPermissions();
     await this.getAllUsers();
   }
 
@@ -658,8 +658,8 @@ export default class CortxIAMUserManagement extends Vue {
   }
 
   public async checkPermissions() {
-    const routerApp: any = this;
-    if (routerApp.$hasAccessToCsm(userPermissions.s3accounts + userPermissions.delete)) {
+    const vueInstance: any = this;
+    if (vueInstance.$hasAccessToCsm(userPermissions.s3accounts + userPermissions.delete)) {
       this.isDeleteAccountAllowed = true;
     }
   }

--- a/gui/src/components/s3/s3.json
+++ b/gui/src/components/s3/s3.json
@@ -62,6 +62,8 @@
       "account_id":"Account id",
       "canonical_id":"Canonical id",
       "reset-password": "Reset password",
+      "update-password": "Update password",
+      "delete-account": "Delete Account",
       "reset-btn": "Reset"
     },
     "bucket": {
@@ -156,6 +158,8 @@
       "account_id":"Account id",
       "canonical_id":"Canonical id",
       "reset-password": "Reset password",
+      "update-password": "Update password",
+      "delete-account": "Delete Account",
       "reset-btn": "Reset"
     },
     "bucket": {


### PR DESCRIPTION
# UI

 S3 and CSM UI : Remove CSM users get call from s3 and correction of success message for reset password

 

## Problem Statement
<pre>
  <code>
    Story Ref (if any): EOS-18713 UI: Reset password success message correction and removing get csm users call from S3
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
- Account name in success message as 'undefined' for reset password functionality.
- Extra get call for CSM users on s3 accounts tab for S3 login
  </code>
</pre>
## Solution/Screenshots
 <pre>
  <code>
- Reset password success message showing name of account for which password is reset.
- Removed CSM users get call from s3 accounts. 
  </code>
</pre>
I am user reset password:
![image](https://user-images.githubusercontent.com/71690421/111583517-978eaa00-87e2-11eb-93ed-c1ccd1686398.png)
S3 account reset password:
![image](https://user-images.githubusercontent.com/71690421/111588049-0cfd7900-87e9-11eb-9342-6756e88f03ed.png)


## Unit Test Cases
<pre>
  <code>
- Reset password success message showing account name
- Get call for CSM users is removed

  </code>
</pre>

Signed-off-by: Vrishali Danave <vrishali.danave@seagate.com>