### PR TITLE
Alert API is removed from S3 account login

### DIFF
--- a/gui/src/components/header/header-bar.vue
+++ b/gui/src/components/header/header-bar.vue
@@ -65,6 +65,7 @@ import { Component, Vue, Prop } from "vue-property-decorator";
 import store from "../../store/store";
 import VueNativeSock from "vue-native-websocket";
 import i18n from "../../i18n";
+import { userPermissions } from "../../common/user-permissions-map"
 
 @Component({
   name: "HeaderBar"
@@ -85,7 +86,10 @@ export default class HeaderBar extends Vue {
       reconnectionAttempts: 5, // (Number) number of reconnection attempts before giving up (Infinity),
       reconnectionDelay: 3000 // (Number) how long to initially wait before attempting a new (1000) })
     });
-    this.$store.dispatch("alertDataAction");
+    const vueInstance: any = this;
+    if (vueInstance.$hasAccessToCsm(userPermissions.users + userPermissions.list)) {
+      this.$store.dispatch("alertDataAction");
+    }
     const usernameStr = localStorage.getItem(this.$data.constStr.username);
     if (usernameStr) {
       this.username = usernameStr;

--- a/gui/src/components/header/header-bar.vue
+++ b/gui/src/components/header/header-bar.vue
@@ -87,7 +87,7 @@ export default class HeaderBar extends Vue {
       reconnectionDelay: 3000 // (Number) how long to initially wait before attempting a new (1000) })
     });
     const vueInstance: any = this;
-    if (vueInstance.$hasAccessToCsm(userPermissions.users + userPermissions.list)) {
+    if (vueInstance.$hasAccessToCsm(userPermissions.alerts + userPermissions.list)) {
       this.$store.dispatch("alertDataAction");
     }
     const usernameStr = localStorage.getItem(this.$data.constStr.username);


### PR DESCRIPTION
# UI

 S3 UI : Remove Alert API get call from s3 which was unwanted.
 

## Problem Statement
<pre>
  <code>
    Story Ref (if any): EOS-19052 UI: Alerts Api getting called when logged -in with S3 account user which is not required.
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>

- Alerts API getting called when logged-in with S3 account user which is returning 403 error and not required as s3 account user does not have access to alerts.

- R2:Error on S3 account user Login with Some API failure .

  </code>
</pre>
## Solution/Screenshots
 <pre>
  <code>
- Removed Alert API get call from S3 and hence error on login also removed.
- User should get logged in with no any errors.
  </code>
</pre>

![image](https://user-images.githubusercontent.com/71690421/113561892-e9c52d00-9622-11eb-84e8-ff835e8387ab.png)


## Unit Test Cases
<pre>
  <code>
- Logged in to the S3 account and verified that no alerts API is getting called.
- User is now able to login with no any errors.

  </code>
</pre>



Signed-off-by: Vrishali Danave <vrishali.danave@seagate.com>