### PR TITLE
EOS-19101:Delete Bucket Policy button remains in disabled state after adding bucket policy to the bucket and only getting enable after page refresh

### DIFF
--- a/gui/src/components/s3/bucket-creation.vue
+++ b/gui/src/components/s3/bucket-creation.vue
@@ -488,7 +488,7 @@ export default class CortxBucketCreation extends Vue {
         apiRegister.bucket_policy + "/" + bucketname
       );
       this.policyJSON = JSON.stringify(res.data, null, 4);
-      this.noBucketPolicy = false;
+      this.policyJSON ?  this.noBucketPolicy = false :  this.noBucketPolicy = true;
     } catch (error) {
       this.policyJSON = "";
       this.noBucketPolicy = true;

--- a/gui/src/components/s3/bucket-creation.vue
+++ b/gui/src/components/s3/bucket-creation.vue
@@ -488,6 +488,7 @@ export default class CortxBucketCreation extends Vue {
         apiRegister.bucket_policy + "/" + bucketname
       );
       this.policyJSON = JSON.stringify(res.data, null, 4);
+      this.noBucketPolicy = false;
     } catch (error) {
       this.policyJSON = "";
       this.noBucketPolicy = true;


### PR DESCRIPTION
# UI

 CSM UI :Delete Bucket Policy button remains in disabled state after adding bucket policy to the bucket and only getting enable after page refresh

## Problem Statement
<pre>
  <code>
    Story Ref (if any):EOS-19101
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
Delete Bucket Policy button remains in disabled state after adding bucket policy to the bucket and only getting enable after page refresh
  </code>
</pre>
## Solution/Screenshots

previous screen when bucket policy update :
![image](https://user-images.githubusercontent.com/66409360/113813804-337e5680-978e-11eb-98e3-b161090df6c9.png)

latest screen if bucket policy update:
![image](https://user-images.githubusercontent.com/66409360/113813866-50b32500-978e-11eb-9d15-a9494c568966.png)
if policy not set previously delete button will disable 
![image](https://user-images.githubusercontent.com/66409360/113868491-59771b80-97cd-11eb-85f0-86d327b01f77.png)




<pre>
  <code>
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
   1)created new bucket
   2) added bucket policy
   3) update bucket policy and close the popup
   4)gain click on edit icon and open bucket policy  popup
   5) check delete button is enable or not
  </code>
</pre>Signed-off-by: Jayshree More <jayshree.more@seagate.com>