### PR TITLE
EOS-19167 GUI update to make calls to v2 version of API

### DIFF
--- a/gui/src/services/api-register.ts
+++ b/gui/src/services/api-register.ts
@@ -14,7 +14,7 @@
 * For any questions about this software or licensing,
 * please email opensource@seagate.com or cortx-questions@seagate.com.
 */
-export const version = "v1";
+export const version = "v2";
 
 export default {
   all_alerts: `/api/${version}/alerts`,

--- a/gui/src/services/api.ts
+++ b/gui/src/services/api.ts
@@ -55,7 +55,7 @@ axios.interceptors.response.use(
   },
   error => {
     // Handle Unauthorised response. Re-route to login page if unauthorised response received.
-    if (error.response && error.response.status === 401 && !error.request.responseURL.includes("api/v1/login")) {
+    if (error.response && error.response.status === 401 && !error.request.responseURL.includes("api/v2/login")) {
       const constStr = require("../common/const-string.json");
       localStorage.removeItem(constStr.access_token);
       localStorage.removeItem(constStr.username);


### PR DESCRIPTION
Signed-off-by: Naresh Gopalakrishnan <naresh.gopalakrishnan@seagate.com>

## Problem Statement
<pre>
<code>
EOS-19167: GUI REST API Movement to V2 REST API version
</code>
</pre>
## Unit testing on RPM done
<pre>
<code>
No
</code>
</pre>
## Problem Description
<pre>
<code>
CSM-Agent and CSM-Web now supports v2 version of API. CSM-GUI needs to be updated to make calls to v2.
</code>
</pre>
## Solution/Screenshots
![image](https://user-images.githubusercontent.com/52106625/113869099-f6d24f80-97cd-11eb-93bd-fa0a052fe35b.png)


## Unit Test Cases
<pre>
<code>
1) After making the change, checked whether the calls in GUI are made to /api/v2 path.
</code>
</pre>