### PR TITLE
Included options parameter in swaggerUi.setup

### DIFF
--- a/web/src/config/client_swagger.json
+++ b/web/src/config/client_swagger.json
@@ -6,10 +6,10 @@
   },
   "servers": [
     {
-      "url": "/api/v1"
+      "url": "/api/v2"
     },
     {
-      "url": "/api/v2"
+      "url": "/api/v1"
     }
   ],
   "paths": {

--- a/web/src/config/swagger.json
+++ b/web/src/config/swagger.json
@@ -6,10 +6,10 @@
   },
   "servers": [
     {
-      "url": "/api/v1"
+      "url": "/api/v2"
     },
     {
-      "url": "/api/v2"
+      "url": "/api/v1"
     }
   ],
   "paths": {

--- a/web/src/middleware/api-docs.ts
+++ b/web/src/middleware/api-docs.ts
@@ -24,6 +24,6 @@ export const handleAPIDocs = (router: Router) => {
     customCssUrl: '/public/custom.css',
     customJs: '/public/custom.js'
   };
-  router.use("/api-docs", swaggerUi.serveFiles(swaggerDocument, options), swaggerUi.setup(swaggerDocument));
-  router.use("/client-api-docs", swaggerUi.serveFiles(clientSwaggerDocument, options), swaggerUi.setup(clientSwaggerDocument));
+  router.use("/api-docs", swaggerUi.serveFiles(swaggerDocument, options), swaggerUi.setup(swaggerDocument, options));
+  router.use("/client-api-docs", swaggerUi.serveFiles(clientSwaggerDocument, options), swaggerUi.setup(clientSwaggerDocument, options));
 }


### PR DESCRIPTION
Signed-off-by: Naresh Gopalakrishnan <naresh.gopalakrishnan@seagate.com>

## Problem Statement
<pre>
<code>
EOS-18971: CSM-Web: Update Swagger documentation to support v2 version
</code>
</pre>
## Unit testing on RPM done
<pre>
<code>
No
</code>
</pre>
## Problem Description
<pre>
<code>
A small issue occurred while updating the Swagger document. The label for dropdown should be 'Base Path' instead of 'Servers'. Also, '/api/v2' should be the default path.
</code>
</pre>
## Solution/Screenshots
Before making the change

![image](https://user-images.githubusercontent.com/52106625/114182948-e0a8c880-9960-11eb-84ca-be91e2896f28.png)


After making the change

![image](https://user-images.githubusercontent.com/52106625/114182552-5f513600-9960-11eb-9957-545df056e46f.png)

## Unit Test Cases
<pre>
<code>
1) Checked whether the dropdown label is displayed as 'Base Path'
2) Checked whether '/api/v2' is the default path.
</code>
</pre>