### PR TITLE
Eos 19461 remove last update description field from UI if its 'unknown_desc'

### DIFF
--- a/gui/src/components/maintenance/cortx-software.vue
+++ b/gui/src/components/maintenance/cortx-software.vue
@@ -47,7 +47,7 @@
           </td>
           <td style="padding-top: 2px;">{{ lastUpgradeStatus.version }}</td>
         </tr>
-        <tr v-if="lastUpgradeStatus.description">
+        <tr v-if="lastUpgradeStatus.description && lastUpgradeStatus.description !== 'unknown_desc'">
           <td>
             <label class="cortx-text-bold">{{ $t("maintenance.lastUpdateDescription") }}:</label>
           </td>


### PR DESCRIPTION
# UI

<pre>
  <code>
"unknown_desc" is always shown against last update description when we upload or perform software update
 
  </code>
</pre>

## Problem Statement
<pre>
  <code>
    Story Ref (if any): EOS-18875 UI: Remove last update description field from the UI when it is "unknown_desc" 
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>

  No - Unit testing currently done with the Mock data.

  </code>
</pre>
## Problem Description
<pre>
  <code>

- "unknown_desc" is always shown against last update description when we upload or perform software update

  </code>
</pre>
## Solution/Screenshots
<pre>
  <code>
 
- Removed last update description field when 'unknown_desc' is returned in the response.

  </code>
</pre>
![image](https://user-images.githubusercontent.com/71690421/114751674-112e9f00-9d73-11eb-989c-0b765086b570.png)

## Unit Test Cases
<pre>
  <code>
CSM Login:
- Login to CSM UI
- click on maintenance link
- Click on the Software option
- Verify response from 'hotfix/status' API, if description in the response is 'unknown_desc' then last update description not showing on the UI.
- Verify response from 'hotfix/status' API, if description in the response is other than 'unknown_desc' then last update description shown on the UI.
  </code>

</pre>



Signed-off-by: Vrishali Danave <vrishali.danave@seagate.com>