### PR TITLE
EOS-19095 - Manage path is updated based on CSM and S3 account login

### DIFF
--- a/gui/src/components/navigation/nav-bar.vue
+++ b/gui/src/components/navigation/nav-bar.vue
@@ -101,6 +101,11 @@ export default class CortxNavBar extends Vue {
 
   public mounted() {
     this.brandName = process.env.VUE_APP_BRANDNAME !== "CORTX";
+    const vueInstance: any = this;
+    if (!vueInstance.$hasAccessToCsm(vueInstance.$cortxUserPermissions.stats + vueInstance.$cortxUserPermissions.list) &&
+      vueInstance.$hasAccessToCsm(vueInstance.$cortxUserPermissions.s3accounts + vueInstance.$cortxUserPermissions.delete)) {
+      this.navItems[2].path = "/manage/s3";
+    }
   }
 
   get alertNotifications() {

--- a/gui/src/router.ts
+++ b/gui/src/router.ts
@@ -161,7 +161,10 @@ const router = new Router({
               path: "",
               name: "provisioning-menu",
               component: CortxProvisioningMenu,
-              meta: { requiresAuth: true }
+              meta: { requiresAuth: true,
+                requiredAccess:
+                  userPermissions.users + userPermissions.list
+              }
             },
             {
               path: "s3",
@@ -170,7 +173,7 @@ const router = new Router({
               meta: {
                 requiresAuth: true,
                 requiredAccess:
-                  userPermissions.s3accounts + userPermissions.list
+                  userPermissions.s3accounts + userPermissions.delete
               }
             },
             {


### PR DESCRIPTION
# UI
<pre>
  <code>
On Click on Manage menu IAM users and Buckets tab are getting vanished for S3 account users
  </code>
</pre>

## Problem Statement
<pre>
  <code>
    Story Ref (if any): EOS-19095 UI: On click of manage, 'manage/s3' should be shown for s3 accounts  and 'manage/' for CSM users.
  </code>
</pre>

## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>

## Problem Description
<pre>
  <code>
- On Click on Manage menu IAM users and Buckets tab are getting vanished for S3 account users
  </code>
</pre>

## Solution/Screenshots
<pre>
  <code>
- Corrected routing path for manage navigation menu:
- For CSM users: '/manage'
- For S3 users: '/manage/s3'
  </code>
</pre>
![image](https://user-images.githubusercontent.com/71690421/114849893-d7ef4100-9dfd-11eb-95d4-cc069880e56e.png)


## Unit Test Cases
<pre>
  <code>
- Login to S3 accounts UI
- Click on manage link
- Verified router path '/manage/s3' and Bucket and I AM User tabs are not vanishing
  </code>
</pre>



Signed-off-by: Vrishali Danave <vrishali.danave@seagate.com>