### PR TITLE
[cortx-1.0]EOS-16157: Severity for system full alert is wrong.

### DIFF
--- a/gui/src/components/alerts/alert-large.vue
+++ b/gui/src/components/alerts/alert-large.vue
@@ -101,7 +101,7 @@
             <div>
               <span>{{ $t("alerts.resourceType") }}: {{ props.item.module_name }}</span><br />
               <span>{{ $t("alerts.resourceId") }}: {{ props.item.resource_id }} | {{ $t("alerts.state") }}: {{ props.item.state }}</span><br />
-              <span>{{ $t("alerts.nodeId") }}: {{ props.item.node_id }}</span>
+              <span>{{ $t("alerts.host_name") }}: {{ props.item.hostname }}</span>
             </div>
             <div>
               <span v-if="props.item.module_type === 'logical_volume'"
@@ -146,35 +146,8 @@
           <td>
             <div
               style="margin: auto;"
-              v-if="
-                props.item.severity === alertStatus.critical ||
-                  props.item.severity === alertStatus.error || 
-                  props.item.severity === alertStatus.alert
-              "
-              v-bind:title="props.item.severity"
-              class="cortx-status-chip cortx-chip-alert"
-            ></div>
-            <div
-              style="margin: auto;"
-              title="warning"
-              v-else-if="props.item.severity === alertStatus.warning"
-              class="cortx-status-chip cortx-chip-warning"
-            ></div>
-            <div
-              style="margin: auto;"
-              v-if="props.item.severity === alertStatus.informational"
-              title="info"
-              class="cortx-status-chip cortx-chip-information"
-            ></div>
-             <div
-              style="margin: auto;"
-              v-if="(props.item.severity !== alertStatus.informational) 
-              && (props.item.severity !== alertStatus.warning)
-              && (props.item.severity !== alertStatus.critical && 
-              props.item.severity !== alertStatus.error 
-              && props.item.severity !== alertStatus.alert)"
               :title="props.item.severity"
-              class="cortx-status-chip cortx-chip-others"
+              :class="getAlertSeverityStyleClass(props.item.severity)"
             ></div>
           </td>
           <td v-cortx-alert-tbl-description="props.item"></td>
@@ -243,12 +216,15 @@ import AlertsMixin from "./../../mixins/alerts";
 import CortxTabs, { TabsInfo } from "./../widgets/cortx-tabs.vue";
 import CortxAlertComments from "./alert-comments.vue";
 import { alertTblDescriptionDirective } from "./alert-description-directive";
-import i18n from "../../i18n";
+import i18n from "./alert.json";
 
 @Component({
   name: "cortx-alert-large",
   components: { CortxTabs, CortxAlertComments },
-  directives: { "cortx-alert-tbl-description": alertTblDescriptionDirective }
+  directives: { "cortx-alert-tbl-description": alertTblDescriptionDirective },
+  i18n: {
+    messages: i18n
+  }
 })
 export default class CortxAlertLarge extends Mixins(AlertsMixin) {
   public isShowCommentsDialog: boolean = false;

--- a/gui/src/components/alerts/alert-medium.vue
+++ b/gui/src/components/alerts/alert-medium.vue
@@ -93,38 +93,9 @@
             <td>
               <div
                 style="margin: auto;"
-                v-if="
-                  props.item.severity === alertStatus.critical ||
-                    props.item.severity === alertStatus.error ||
-                props.item.severity === alertStatus.error || 
-                    props.item.severity === alertStatus.error ||
-                    props.item.severity === alertStatus.alert
-                "
-                v-bind:title="props.item.severity"
-                class="cortx-status-chip cortx-chip-alert"
+                :title="props.item.severity"
+                :class="getAlertSeverityStyleClass(props.item.severity)"
               ></div>
-              <div
-                style="margin: auto;"
-                v-else-if="props.item.severity === alertStatus.warning"
-                title="warning"
-                class="cortx-status-chip cortx-chip-warning"
-              ></div>
-              <div
-                style="margin: auto;"
-                v-if="props.item.severity === alertStatus.informational"
-                title="info"
-                class="cortx-status-chip cortx-chip-information"
-              ></div>
-               <div
-              style="margin: auto;"
-              v-if="(props.item.severity !== alertStatus.informational) 
-              && (props.item.severity !== alertStatus.warning)
-              && (props.item.severity !== alertStatus.critical 
-              && props.item.severity !== alertStatus.error 
-              && props.item.severity !== alertStatus.alert)"
-              :title="props.item.severity"
-              class="cortx-status-chip cortx-chip-others"
-            ></div>
             </td>
             <td v-cortx-alert-tbl-description="props.item"></td>
           </tr>
@@ -138,13 +109,16 @@ import { Component, Vue, Prop, Mixins } from "vue-property-decorator";
 import AlertsMixin from "./../../mixins/alerts";
 import CortxHealthSummary from "../system/health-summary.vue";
 import { alertTblDescriptionDirective } from "./alert-description-directive";
+import i18n from "./alert.json";
 import { EVENT_BUS } from "../../main";
-import i18n from "../../i18n";
 
 @Component({
   name: "cortx-alert-medium",
   components: { CortxHealthSummary },
-  directives: { "cortx-alert-tbl-description": alertTblDescriptionDirective }
+  directives: { "cortx-alert-tbl-description": alertTblDescriptionDirective },
+  i18n: {
+    messages: i18n
+  }
 })
 export default class CortxAlertMedium extends Mixins(AlertsMixin) {
 

--- a/gui/src/components/alerts/alert-occurrences.vue
+++ b/gui/src/components/alerts/alert-occurrences.vue
@@ -76,35 +76,8 @@
           <td>
             <div
               style="margin: auto;"
-              v-if="props.item.severity === alertStatus.warning"
-              class="cortx-status-chip cortx-chip-warning"
-              title="warning"
-            ></div>
-            <div
-              style="margin: auto;"
-              v-else-if="props.item.severity ===alertStatus.critical || props.item.severity === alertStatus.error"
-              class="cortx-status-chip cortx-chip-alert"
-              v-bind:title="props.item.severity"
-            ></div>
-            <div
-              style="margin: auto;"
-              v-else-if="props.item.severity ===alertStatus.warning"
-              class="cortx-status-chip cortx-chip-warning"
-              title="warning"
-            ></div>
-            <div
-              style="margin: auto;"
-              v-if="props.item.severity === alertStatus.informational"
-              class="cortx-status-chip cortx-chip-information"
-              title="info"
-            ></div>
-             <div
-              style="margin: auto;"
-              v-if="(props.item.severity !== alertStatus.informational) 
-              && (props.item.severity !== alertStatus.warning)
-              && (props.item.severity !== alertStatus.critical && props.item.severity !== alertStatus.error)"
-              title="other"
-              class="cortx-status-chip cortx-chip-others"
+              :title="props.item.severity"
+              :class="getAlertSeverityStyleClass(props.item.severity)"
             ></div>
           </td>
           <td v-cortx-alert-tbl-description="props.item"></td>
@@ -129,11 +102,14 @@ import { Api } from "./../../services/api";
 import apiRegister from "./../../services/api-register";
 import { AlertQueryParam, AlertObject } from "./../../models/alert";
 import { alertTblDescriptionDirective } from "./alert-description-directive";
-import i18n from "../../i18n";
+import i18n from "./alert.json";
 
 @Component({
   name: "cortx-alert-occurrences",
-  directives: { "cortx-alert-tbl-description": alertTblDescriptionDirective }
+  directives: { "cortx-alert-tbl-description": alertTblDescriptionDirective },
+  i18n: {
+    messages: i18n
+  }
 })
 export default class CortxAlertOccurrences extends Vue {
   public alertObject: AlertObject = {} as AlertObject;
@@ -213,6 +189,32 @@ export default class CortxAlertOccurrences extends Vue {
     return {
       alertStatus: require("./../../common/const-string.json")
     };
+  }
+
+  public getAlertSeverityStyleClass(severity: string) {
+    let severityStyleClass = "";
+
+    switch (severity) {
+      case "critical":
+      case "error":
+      case "alert":
+        severityStyleClass = "cortx-chip-alert";
+        break;
+
+      case "warning":
+        severityStyleClass = "cortx-chip-warning";
+        break;
+
+      case "informational":
+        severityStyleClass = "cortx-chip-information";
+        break;
+
+      default:
+        severityStyleClass = "cortx-chip-others";
+        break;
+    }
+
+    return `cortx-status-chip ${severityStyleClass}`;
   }
 }
 </script>

--- a/gui/src/mixins/alerts.ts
+++ b/gui/src/mixins/alerts.ts
@@ -116,6 +116,32 @@ export default class AlertsMixin extends Vue {
     this.$store.dispatch("alertDataAction");
   }
 
+  public getAlertSeverityStyleClass(severity: string) {
+    let severityStyleClass = "";
+
+    switch (severity) {
+      case "critical":
+      case "error":
+      case "alert":
+        severityStyleClass = "cortx-chip-alert";
+        break;
+
+      case "warning":
+        severityStyleClass = "cortx-chip-warning";
+        break;
+
+      case "informational":
+        severityStyleClass = "cortx-chip-information";
+        break;
+
+      default:
+        severityStyleClass = "cortx-chip-others";
+        break;
+    }
+
+    return `cortx-status-chip ${severityStyleClass}`;
+  }
+
   get currentPage() {
     return this.$store.getters["alerts/getCurrentPage"];
   }


### PR DESCRIPTION
# UI
<pre>
  <code>
Alert severity should be shown same across all pages
  </code>
</pre>

## Problem Statement
<pre>
  <code>
    Story Ref (if any): EOS-16157: Severity for system full alert is wrong.
  </code>
</pre>

## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>

## Problem Description
<pre>
  <code>
Severity for 90% full alert is shown as red (alert). But alert detail page for that alert shows severity as brown
  </code>
</pre>

## Solution/Screenshots
<pre>
  <code>
- Fixed the issue in alert details screen
  </code>
</pre>
![alert_bug_fix_01](https://user-images.githubusercontent.com/66473115/115383741-d655bc80-a1f3-11eb-95eb-ad4fc5cb593b.JPG)

![alert_bug_fix_02](https://user-images.githubusercontent.com/66473115/115383747-d786e980-a1f3-11eb-8036-21685050be27.JPG)


Signed-off-by: Shri Metta <shri.metta@seagate.com>