### PR TITLE
[main]EOS-16157: Severity for system full alert is wrong.

### DIFF
--- a/gui/src/components/alerts/alert-large.vue
+++ b/gui/src/components/alerts/alert-large.vue
@@ -146,35 +146,8 @@
           <td>
             <div
               style="margin: auto;"
-              v-if="
-                props.item.severity === alertStatus.critical ||
-                  props.item.severity === alertStatus.error || 
-                  props.item.severity === alertStatus.alert
-              "
-              v-bind:title="props.item.severity"
-              class="cortx-status-chip cortx-chip-alert"
-            ></div>
-            <div
-              style="margin: auto;"
-              title="warning"
-              v-else-if="props.item.severity === alertStatus.warning"
-              class="cortx-status-chip cortx-chip-warning"
-            ></div>
-            <div
-              style="margin: auto;"
-              v-if="props.item.severity === alertStatus.informational"
-              title="info"
-              class="cortx-status-chip cortx-chip-information"
-            ></div>
-             <div
-              style="margin: auto;"
-              v-if="(props.item.severity !== alertStatus.informational) 
-              && (props.item.severity !== alertStatus.warning)
-              && (props.item.severity !== alertStatus.critical && 
-              props.item.severity !== alertStatus.error 
-              && props.item.severity !== alertStatus.alert)"
               :title="props.item.severity"
-              class="cortx-status-chip cortx-chip-others"
+              :class="getAlertSeverityStyleClass(props.item.severity)"
             ></div>
           </td>
           <td v-cortx-alert-tbl-description="props.item"></td>

--- a/gui/src/components/alerts/alert-medium.vue
+++ b/gui/src/components/alerts/alert-medium.vue
@@ -93,38 +93,9 @@
             <td>
               <div
                 style="margin: auto;"
-                v-if="
-                  props.item.severity === alertStatus.critical ||
-                    props.item.severity === alertStatus.error ||
-                props.item.severity === alertStatus.error || 
-                    props.item.severity === alertStatus.error ||
-                    props.item.severity === alertStatus.alert
-                "
-                v-bind:title="props.item.severity"
-                class="cortx-status-chip cortx-chip-alert"
+                :title="props.item.severity"
+                :class="getAlertSeverityStyleClass(props.item.severity)"
               ></div>
-              <div
-                style="margin: auto;"
-                v-else-if="props.item.severity === alertStatus.warning"
-                title="warning"
-                class="cortx-status-chip cortx-chip-warning"
-              ></div>
-              <div
-                style="margin: auto;"
-                v-if="props.item.severity === alertStatus.informational"
-                title="info"
-                class="cortx-status-chip cortx-chip-information"
-              ></div>
-               <div
-              style="margin: auto;"
-              v-if="(props.item.severity !== alertStatus.informational) 
-              && (props.item.severity !== alertStatus.warning)
-              && (props.item.severity !== alertStatus.critical 
-              && props.item.severity !== alertStatus.error 
-              && props.item.severity !== alertStatus.alert)"
-              :title="props.item.severity"
-              class="cortx-status-chip cortx-chip-others"
-            ></div>
             </td>
             <td v-cortx-alert-tbl-description="props.item"></td>
           </tr>

--- a/gui/src/components/alerts/alert-occurrences.vue
+++ b/gui/src/components/alerts/alert-occurrences.vue
@@ -76,35 +76,8 @@
           <td>
             <div
               style="margin: auto;"
-              v-if="props.item.severity === alertStatus.warning"
-              class="cortx-status-chip cortx-chip-warning"
-              title="warning"
-            ></div>
-            <div
-              style="margin: auto;"
-              v-else-if="props.item.severity ===alertStatus.critical || props.item.severity === alertStatus.error"
-              class="cortx-status-chip cortx-chip-alert"
-              v-bind:title="props.item.severity"
-            ></div>
-            <div
-              style="margin: auto;"
-              v-else-if="props.item.severity ===alertStatus.warning"
-              class="cortx-status-chip cortx-chip-warning"
-              title="warning"
-            ></div>
-            <div
-              style="margin: auto;"
-              v-if="props.item.severity === alertStatus.informational"
-              class="cortx-status-chip cortx-chip-information"
-              title="info"
-            ></div>
-             <div
-              style="margin: auto;"
-              v-if="(props.item.severity !== alertStatus.informational) 
-              && (props.item.severity !== alertStatus.warning)
-              && (props.item.severity !== alertStatus.critical && props.item.severity !== alertStatus.error)"
-              title="other"
-              class="cortx-status-chip cortx-chip-others"
+              :title="props.item.severity"
+              :class="getAlertSeverityStyleClass(props.item.severity)"
             ></div>
           </td>
           <td v-cortx-alert-tbl-description="props.item"></td>
@@ -216,6 +189,32 @@ export default class CortxAlertOccurrences extends Vue {
     return {
       alertStatus: require("./../../common/const-string.json")
     };
+  }
+
+  public getAlertSeverityStyleClass(severity: string) {
+    let severityStyleClass = "";
+
+    switch (severity) {
+      case "critical":
+      case "error":
+      case "alert":
+        severityStyleClass = "cortx-chip-alert";
+        break;
+
+      case "warning":
+        severityStyleClass = "cortx-chip-warning";
+        break;
+
+      case "informational":
+        severityStyleClass = "cortx-chip-information";
+        break;
+
+      default:
+        severityStyleClass = "cortx-chip-others";
+        break;
+    }
+
+    return `cortx-status-chip ${severityStyleClass}`;
   }
 }
 </script>

--- a/gui/src/mixins/alerts.ts
+++ b/gui/src/mixins/alerts.ts
@@ -116,6 +116,32 @@ export default class AlertsMixin extends Vue {
     this.$store.dispatch("alertDataAction");
   }
 
+  public getAlertSeverityStyleClass(severity: string) {
+    let severityStyleClass = "";
+
+    switch (severity) {
+      case "critical":
+      case "error":
+      case "alert":
+        severityStyleClass = "cortx-chip-alert";
+        break;
+
+      case "warning":
+        severityStyleClass = "cortx-chip-warning";
+        break;
+
+      case "informational":
+        severityStyleClass = "cortx-chip-information";
+        break;
+
+      default:
+        severityStyleClass = "cortx-chip-others";
+        break;
+    }
+
+    return `cortx-status-chip ${severityStyleClass}`;
+  }
+
   get currentPage() {
     return this.$store.getters["alerts/getCurrentPage"];
   }


### PR DESCRIPTION
# UI
<pre>
  <code>
Alert severity should be shown same across all pages
  </code>
</pre>

## Problem Statement
<pre>
  <code>
    Story Ref (if any): EOS-16157: Severity for system full alert is wrong.
  </code>
</pre>

## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>

## Problem Description
<pre>
  <code>
Severity for 90% full alert is shown as red (alert). But alert detail page for that alert shows severity as brown
  </code>
</pre>

## Solution/Screenshots
<pre>
  <code>
- Fixed the issue in alert details screen
  </code>
</pre>
![alert_bug_fix_01](https://user-images.githubusercontent.com/66473115/115383741-d655bc80-a1f3-11eb-95eb-ad4fc5cb593b.JPG)

![alert_bug_fix_02](https://user-images.githubusercontent.com/66473115/115383747-d786e980-a1f3-11eb-8036-21685050be27.JPG)



Signed-off-by: Shri Metta <shri.metta@seagate.com>