### PR TITLE
Disabled health related pages as currently it is unsupported feature

### DIFF
--- a/gui/src/components/alerts/alert-medium.vue
+++ b/gui/src/components/alerts/alert-medium.vue
@@ -16,7 +16,12 @@
 */
 <template>
   <div id="alertMediumContainer">
-    <cortx-health-summary />
+    <!--
+      Health-Currently-Unsupported
+      Commenting as this is unsupported feature. Will uncomment this
+      when the feature will be supported.
+    -->
+    <!--cortx-health-summary /-->
     <div style="height: 30px;">
       <div class="cortx-alert-title" id="alert-new-alerts">{{ $t("alerts.newAlerts") }}</div>
       <img

--- a/gui/src/components/navigation/nav-bar.vue
+++ b/gui/src/components/navigation/nav-bar.vue
@@ -62,6 +62,12 @@ export default class CortxNavBar extends Vue {
       iconActive: require("@/assets/navigation/dashboard-white.svg"),
       requiredAccess: "alerts"
     },
+    /**
+     * Health-Currently-Unsupported
+     * Commenting as this is unsupported feature. Will uncomment this
+     * when the feature will be supported.
+     */
+    /*
     {
       title: "Health",
       path: "/health",
@@ -69,6 +75,7 @@ export default class CortxNavBar extends Vue {
       iconActive: require("@/assets/navigation/health-white.svg"),
       requiredAccess: "sysconfig"
     },
+    */
     {
       title: "Manage",
       path: "/manage",

--- a/gui/src/router.ts
+++ b/gui/src/router.ts
@@ -187,6 +187,12 @@ const router = new Router({
             }
           ]
         },
+        /**
+         * Health-Currently-Unsupported
+         * Commenting as this is unsupported feature. Will uncomment this
+         * when the feature will be supported.
+         */
+        /*
         {
           path: "health",
           component: CortxHealth,
@@ -215,6 +221,7 @@ const router = new Router({
             }
           ]
         },
+        */
         {
           path: "settings",
           component: CortxSettings,


### PR DESCRIPTION
# UI

Disable Health related pages
 

## Problem Statement
<pre>
  <code>
    Disabled health related pages as currently it is unsupported feature
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
Helath realted pages show error as it is not supoorted currently
  </code>
</pre>
## Solution/Screenshots
 <pre>
  <code>
Disabled health related pages
  </code>
</pre>

![health-remove](https://user-images.githubusercontent.com/66473115/116046646-e73d7c80-a690-11eb-84ec-2bc59c4acd59.JPG)

![health-remove-01](https://user-images.githubusercontent.com/66473115/116046652-e86ea980-a690-11eb-8192-4d6b6c7c2674.JPG)

## Unit Test Cases
<pre>
  <code>
1. Accessed the dashboard. It did not show any error and health summary was not present.
2. Tried accessing health pages. It gave page not found as expected
  </code>
</pre>

Signed-off-by: Shri Metta <shri.metta@seagate.com>