### PR TITLE
EOS-19465 - Cluster ID integration on About page

### DIFF
--- a/gui/src/components/maintenance/cortx-about.vue
+++ b/gui/src/components/maintenance/cortx-about.vue
@@ -72,6 +72,16 @@
             <label>{{ serialNumber }}</label>
           </td>
         </tr>
+        <tr v-if="clusterId">
+          <td>
+            <label class="cortx-text-bold">{{
+              $t("aboutUs.clusterId")
+            }}</label>
+          </td>
+          <td class="cortx-td">
+            <label>{{ clusterId }}</label>
+          </td>
+        </tr>
       </table>
     </div>
     <div class="mt-4">
@@ -281,7 +291,8 @@ export default class Cortxaboutpage extends Vue {
         RELEASE: null,
         COMPONENTS: []
       },
-      serialNumber: "-" as string
+      serialNumber: "-" as string,
+      clusterId: "-" as string
     };
   }
 
@@ -302,6 +313,7 @@ export default class Cortxaboutpage extends Vue {
   public async getApplianceDetails() {
     const res = await Api.getAll(apiRegister.appliance_info);
     this.$data.serialNumber = res.data[0].serial_number;
+    this.$data.clusterId = res.data[0].cluster_id;
   }
   public async getSSLDetails() {
     this.$store.dispatch("systemConfig/showLoader", "Fetching SSL details...");

--- a/gui/src/locales/en.json
+++ b/gui/src/locales/en.json
@@ -252,6 +252,7 @@
         "release": "Release:",
         "COMPONENTS": "COMPONENTS",
         "SerialNumber": "Serial No:",
+        "clusterId": "Cluster ID",
         "common_name_lbl":"Common Name",
         "country_name_lbl":"Country Name",
         "locality_name_lbl":"Locality Name",


### PR DESCRIPTION
# UI

GUI: About section shouldbe updated with cluster id and serial number
 

## Problem Statement
<pre>
  <code>
    Story Ref (if any): EOS-19465 UI: Integration Cluster ID field on UI
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No - Unit testing is done on Backend developer's machine
  </code>
</pre>
## Problem Description
<pre>
  <code>
- Integration of Cluster ID field on About page.
  </code>
</pre>
## Solution/Screenshots
<pre>
  <code>
 
- Added 'Cluster Id' field to the About page UI.

  </code>
</pre>
![MicrosoftTeams-image](https://user-images.githubusercontent.com/71690421/116236553-d23e1780-a77c-11eb-835e-eeb3dfcde55b.png)

## Unit Test Cases
<pre>
  <code>
CSM Login:
- Login to CSM UI
- Click on 'Maintenance' link
- Click on 'About' menu
- Verify Cluster Id field on the UI


  </code>


Signed-off-by: Vrishali Danave <vrishali.danave@seagate.com>