### PR TITLE
EOS-19095 - Updated logic to update manage url path

### DIFF
--- a/gui/src/components/navigation/nav-bar.vue
+++ b/gui/src/components/navigation/nav-bar.vue
@@ -104,7 +104,7 @@ export default class CortxNavBar extends Vue {
     const vueInstance: any = this;
     if (!vueInstance.$hasAccessToCsm(vueInstance.$cortxUserPermissions.stats + vueInstance.$cortxUserPermissions.list) &&
       vueInstance.$hasAccessToCsm(vueInstance.$cortxUserPermissions.s3accounts + vueInstance.$cortxUserPermissions.delete)) {
-      var foundIndex = this.navItems.findIndex(x => x.path == "/manage");
+      let foundIndex = this.navItems.findIndex(x => x.path === "/manage");
       this.navItems[foundIndex].path = "/manage/s3";
     }
   }

--- a/gui/src/components/navigation/nav-bar.vue
+++ b/gui/src/components/navigation/nav-bar.vue
@@ -62,12 +62,6 @@ export default class CortxNavBar extends Vue {
       iconActive: require("@/assets/navigation/dashboard-white.svg"),
       requiredAccess: "alerts"
     },
-    /**
-     * Health-Currently-Unsupported
-     * Commenting as this is unsupported feature. Will uncomment this
-     * when the feature will be supported.
-     */
-    /*
     {
       title: "Health",
       path: "/health",
@@ -75,7 +69,6 @@ export default class CortxNavBar extends Vue {
       iconActive: require("@/assets/navigation/health-white.svg"),
       requiredAccess: "sysconfig"
     },
-    */
     {
       title: "Manage",
       path: "/manage",
@@ -111,7 +104,8 @@ export default class CortxNavBar extends Vue {
     const vueInstance: any = this;
     if (!vueInstance.$hasAccessToCsm(vueInstance.$cortxUserPermissions.stats + vueInstance.$cortxUserPermissions.list) &&
       vueInstance.$hasAccessToCsm(vueInstance.$cortxUserPermissions.s3accounts + vueInstance.$cortxUserPermissions.delete)) {
-      this.navItems[2].path = "/manage/s3";
+      var foundIndex = this.navItems.findIndex(x => x.path == "/manage");
+      this.navItems[foundIndex].path = "/manage/s3";
     }
   }
 

--- a/gui/src/components/navigation/nav-bar.vue
+++ b/gui/src/components/navigation/nav-bar.vue
@@ -34,14 +34,16 @@
         >
           <img class="cortx-nav-item-icon-default" :src="navItem.iconDefault" />
           <img class="cortx-nav-item-icon-active" :src="navItem.iconActive" />
-          <label  :id="navItem.title">{{ navItem.title }}</label>
+          <label :id="navItem.title">{{ navItem.title }}</label>
         </router-link>
       </cortx-has-access>
     </div>
     <div class="cortx-nav-bottom" v-if="brandName">
       <div class="cortx-brand-text">{{ $t("common.poweredBy") }}</div>
-      <img class="cortx-nav-item-icon-default cortx-img-responsive"
-        :src="require('@/assets/Cortx-logo-GRN.svg/')" />
+      <img
+        class="cortx-nav-item-icon-default cortx-img-responsive"
+        :src="require('@/assets/Cortx-logo-GRN.svg/')"
+      />
     </div>
   </div>
 </template>
@@ -102,9 +104,17 @@ export default class CortxNavBar extends Vue {
   public mounted() {
     this.brandName = process.env.VUE_APP_BRANDNAME !== "CORTX";
     const vueInstance: any = this;
-    if (!vueInstance.$hasAccessToCsm(vueInstance.$cortxUserPermissions.stats + vueInstance.$cortxUserPermissions.list) &&
-      vueInstance.$hasAccessToCsm(vueInstance.$cortxUserPermissions.s3accounts + vueInstance.$cortxUserPermissions.delete)) {
-      let foundIndex = this.navItems.findIndex(x => x.path === "/manage");
+    if (
+      !vueInstance.$hasAccessToCsm(
+        vueInstance.$cortxUserPermissions.stats +
+          vueInstance.$cortxUserPermissions.list
+      ) &&
+      vueInstance.$hasAccessToCsm(
+        vueInstance.$cortxUserPermissions.s3accounts +
+          vueInstance.$cortxUserPermissions.delete
+      )
+    ) {
+      const foundIndex = this.navItems.findIndex(x => x.path === "/manage");
       this.navItems[foundIndex].path = "/manage/s3";
     }
   }

--- a/gui/src/router.ts
+++ b/gui/src/router.ts
@@ -187,12 +187,6 @@ const router = new Router({
             }
           ]
         },
-        /**
-         * Health-Currently-Unsupported
-         * Commenting as this is unsupported feature. Will uncomment this
-         * when the feature will be supported.
-         */
-        /*
         {
           path: "health",
           component: CortxHealth,
@@ -221,7 +215,6 @@ const router = new Router({
             }
           ]
         },
-        */
         {
           path: "settings",
           component: CortxSettings,


### PR DESCRIPTION
# UI
<pre>
  <code>
UI: On click of manage link it should not give authorization error
   </code>
</pre>
## Problem Statement
<pre>
  <code>
    Story Ref (if any): EOS-19095 UI: On click of manage link in S3 account, getting error.
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
- Redirect to correct path on click of manage link in S3 account.
  </code>
</pre>
## Solution/Screenshots
<pre>
  <code> 
- Updated logic for manage navigation menu.
- On click of manage link : 
        S3 - it should go to '/manage/s3'
        CSM - it should go to '/manage'
- It should not give 'Access Denied' error.
  </code>
</pre>
![image](https://user-images.githubusercontent.com/71690421/116656143-cf743a00-a9a9-11eb-8d25-30cabaa811fa.png)


## Unit Test Cases
<pre>
  <code>
CSM Login:
- Login to CSM UI
- Click on 'Manage' link
- Click on 'S3 accounts' tab
- Click on 'Manage' link again
- Verify that no access denied error on UI
- Login to S3 UI
- Click on 'I am user' tab
- Click on 'Manage' link again
- Verify that no access denied error on UI
  </code>
</pre>

Signed-off-by: Vrishali Danave <vrishali.danave@seagate.com>