### PR TITLE
EOS-19474 - CSM Audit-Log: Audit log should be shown in tabular format

### DIFF
--- a/gui/src/components/maintenance/auditlog.vue
+++ b/gui/src/components/maintenance/auditlog.vue
@@ -224,37 +224,37 @@ export default class CortxAuditLog extends Vue {
     {
       text: "User",
       value: "user",
-      sortable: true
+      sortable: false
     },
     {
       text: "Remote IP",
       value: "remote_ip",
-      sortable: true
+      sortable: false
     },
     {
       text: "Forwarded For IP",
       value: "forwarded_for_ip",
-      sortable: true
+      sortable: false
     },
     {
       text: "Method",
       value: "method",
-      sortable: true
+      sortable: false
     },
     {
       text: "Path",
       value: "path",
-      sortable: true
+      sortable: false
     },
     {
       text: "User Agent",
       value: "user_agent",
-      sortable: true
+      sortable: false
     },
     {
       text: "Response Code",
       value: "response_code",
-      sortable: true
+      sortable: false
     }
   ];
   public auditLog: any = {

--- a/gui/src/models/download.ts
+++ b/gui/src/models/download.ts
@@ -18,6 +18,10 @@
 export interface AuditLogQueryParam {
     component: string;
     timerange: string;
-    from: string;
-    to: string;
+    start_date: number;
+    end_date: number;
+    sortby?: string;
+    dir?: string;
+    offset?: number;
+    limit?: number;
 }

--- a/gui/src/store/modules/download.ts
+++ b/gui/src/store/modules/download.ts
@@ -30,9 +30,8 @@ export default class Download extends VuexModule {
     public queryParams: AuditLogQueryParam = {
         component: "CSM",
         timerange: "1d",
-        from: "",
-        to: ""
-
+        start_date: 0,
+        end_date: 0
     };
 
     @Action
@@ -41,22 +40,7 @@ export default class Download extends VuexModule {
         try {
             const res = await Api.getFile(apiRegister.auditlogs + "/download/"
                 + queryParams.component.toLowerCase()
-                + "?start_date=" + queryParams.from + "&end_date=" + queryParams.to + "");
-
-            return res;
-        } catch (e) {
-            // tslint:disable-next-line: no-console
-            console.log("err logger: ", e);
-        }
-    }
-    @Action
-    public async showAuditLogs(queryParams: AuditLogQueryParam) {
-        queryParams = queryParams ? queryParams : this.queryParams;
-
-        try {
-            const res = await Api.getAll(apiRegister.auditlogs + "/show/"
-                + queryParams.component.toLowerCase()
-                + "?start_date=" + queryParams.from + "&end_date=" + queryParams.to + "");
+                + "?start_date=" + queryParams.start_date + "&end_date=" + queryParams.end_date + "");
 
             return res;
         } catch (e) {


### PR DESCRIPTION
# UI

CSM Audit-Log: Audit log should be shown in tabular format
 

## Problem Statement
<pre>
  <code>
    Story Ref (if any): EOS-19474 - CSM Audit-Log: Audit log should be shown in tabular format
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
Current Audit logs are shown in simple text format. This needs to be shown in table.
  </code>
</pre>
## Solution/Screenshots
<pre>
  <code>

Added table with pagination and sorting.

  </code>
</pre>
![01-audit-log](https://user-images.githubusercontent.com/66473115/116674178-f2124d00-a9c1-11eb-9b05-5acd51994494.JPG)
![02-audit-log](https://user-images.githubusercontent.com/66473115/116674191-f3437a00-a9c1-11eb-9a22-098f05d05683.JPG)
![03-audit-log](https://user-images.githubusercontent.com/66473115/116674195-f3437a00-a9c1-11eb-8250-a1814dcb15dc.JPG)



## Unit Test Cases
<pre>
  <code>


  </code>


Signed-off-by: Shri Metta <shri.metta@seagate.com>