### PR TITLE
EOS-20547: S3 account management message text on UI correction

### DIFF
--- a/gui/src/components/s3/s3.json
+++ b/gui/src/components/s3/s3.json
@@ -33,7 +33,7 @@
     },
     "account": {
       "configuration": "S3 configuration",
-      "header-text": "Click Download and close to save this information in CSV format.",
+      "header-text": "Create an S3 account. You must log in to the system using S3 account credentials to manage S3 account, IAM users, and buckets.",
       "url-label": "S3 URL:",
       "url-label-no-colon": "S3 URL",
       "name-required": "Account name is required.",


### PR DESCRIPTION
# UI

S3 account management message text on UI correction
 

## Problem Statement
<pre>
  <code>
    Story Ref (if any): EOS-20547 UI: Stable 175: S3 User Management : Text on UI is incorrect.
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
- S3 User Management text on UI is incorrect.
  </code>
</pre>
## Solution/Screenshots
<pre>
  <code>
 
- Added correct text for S3 user management on S3 accounts tab.

  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
CSM Login:
- Login to CSM UI
- Click on Manage link
- Click on S3 account tab
- Verify message under S3 configuration heading
  </code>
</pre>
![image](https://user-images.githubusercontent.com/71690421/118089736-5384e380-b3e6-11eb-8ed4-021d8335b169.png)



Signed-off-by: Vrishali Danave <vrishali.danave@seagate.com>