### PR TITLE
EOS-20550: Delete IAM user tooltip correction

### DIFF
--- a/gui/src/components/s3/iam-user-management.vue
+++ b/gui/src/components/s3/iam-user-management.vue
@@ -101,7 +101,7 @@
                           />
                         </template>
                         <span id="delete-account-tooltip">
-                          {{ $t("s3.account.delete-account") }}
+                          {{ $t("s3.iam.delete-iam") }}
                         </span>
                       </v-tooltip>
                     </div>

--- a/gui/src/components/s3/s3.json
+++ b/gui/src/components/s3/s3.json
@@ -90,6 +90,7 @@
       "user-key-access": "User created:access key and secret key",
       "confirm-msg": "Are you sure you want to delete IAM user",      
       "reset-password": "Reset password",
+      "delete-iam": "Delete IAM User",
       "reset-btn": "Reset"
     }
   }
@@ -186,6 +187,7 @@
       "user-key-access": "User created:access key and secret key",
       "confirm-msg": "Are you sure you want to delete IAM user",
       "reset-password": "Reset password",
+      "delete-iam": "Delete IAM User",
       "reset-btn": "Reset"
     }
   }


### PR DESCRIPTION
# UI

S3iamuser deletion Icon is showing tooltip as Delete Account
 

## Problem Statement
<pre>
  <code>
    Story Ref (if any): EOS-20550: UI: S3iamuser deletion Icon is showing as Delete Account.
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
- S3 delete IAM user tooltip on UI is incorrect.
  </code>
</pre>
## Solution/Screenshots
<pre>
  <code>
 
- Added correct tooltip for S3 IAM user delete icon.

  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
CSM Login:
- Login to S3 accounts
- Click on IAM user tab
- Hover on Delete icon in the table
- Verify tooltip
  </code>
</pre>
![image](https://user-images.githubusercontent.com/71690421/118091528-8def8000-b3e8-11eb-8230-73edd38befa2.png)


Signed-off-by: Vrishali Danave <vrishali.danave@seagate.com>