### PR TITLE
EOS-20700:NodeJS API to get unsupported features from csm agent

### DIFF
--- a/web/src/config/client_swagger.json
+++ b/web/src/config/client_swagger.json
@@ -36,6 +36,29 @@
         }
       }
     },
+    "/unsupported_features": {
+      "get": {
+        "tags": ["Unsupported Features"],
+        "summary": "Gets all the unsupported features",
+        "responses": {
+          "200": {
+            "description": "OK: Unsupported features fetched successfully."
+          },
+          "400": {
+            "description": "Bad Request: Invalid request message received."
+          },
+          "499": {
+            "description": "Call Cancelled: Call cancelled by client."
+          },
+          "500": {
+            "description": "Internal Server Error: When requested resource is not available."
+          }
+        },
+        "content": {
+          "application/json": {}
+        }
+      }
+    },
     "/login": {
       "post": {
         "tags": ["User"],

--- a/web/src/config/swagger.json
+++ b/web/src/config/swagger.json
@@ -36,6 +36,29 @@
         }
       }
     },
+    "/unsupported_features": {
+      "get": {
+        "tags": ["Unsupported Features"],
+        "summary": "Gets all the unsupported features",
+        "responses": {
+          "200": {
+            "description": "OK: Unsupported features fetched successfully."
+          },
+          "400": {
+            "description": "Bad Request: Invalid request message received."
+          },
+          "499": {
+            "description": "Call Cancelled: Call cancelled by client."
+          },
+          "500": {
+            "description": "Internal Server Error: When requested resource is not available."
+          }
+        },
+        "content": {
+          "application/json": {}
+        }
+      }
+    },
     "/preboarding/user": {
       "post": {
         "tags": ["Admin User"],

--- a/web/src/services/api-register.ts
+++ b/web/src/services/api-register.ts
@@ -65,5 +65,6 @@ export default {
   get_health_components_endpt: (version :string) => `/api/${version}/system/health/components`,
   get_health_resources_endpt: (version :string) => `/api/${version}/system/health/resources`,
   get_system_status_endpt: (version :string) => `/api/${version}/system/status`,
-  get_appliance_info_endpt: (version :string) => `/api/${version}/appliance_info`
+  get_appliance_info_endpt: (version :string) => `/api/${version}/appliance_info`,
+  get_unsupported_features_endpt: (version :string) => `/api/${version}/unsupported_features`
 };

--- a/web/src/services/index.ts
+++ b/web/src/services/index.ts
@@ -32,6 +32,7 @@ import firmware from "./firmware/routes";
 import ssl from "./ssl/routes";
 import software from "./software/routes";
 import about from "./about/routes";
+import unsupported_features from "./unsupported_features/routes";
 
 export default [
   ...loginRoutes,
@@ -51,5 +52,6 @@ export default [
   ...firmware,
   ...ssl,
   ...software,
-  ...about
+  ...about,
+  ...unsupported_features
 ];

--- a/web/src/services/unsupported_features/routes.ts
+++ b/web/src/services/unsupported_features/routes.ts
@@ -1,0 +1,44 @@
+/*
+* CORTX-CSM: CORTX Management web and CLI interface.
+* Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Affero General Public License for more details.
+* You should have received a copy of the GNU Affero General Public License
+* along with this program. If not, see <https://www.gnu.org/licenses/>.
+* For any questions about this software or licensing,
+* please email opensource@seagate.com or cortx-questions@seagate.com.
+*/
+import { Request, Response, request, response } from "express";
+import { get_unsupported_features } from "./unsupported-features-controller";
+import { checkApiVersion, checkRequiredParams } from './../../middleware/validator';
+import HttpStatus from 'http-status-codes';
+
+
+/**
+ * It has all the REST APIs to get the unsupported features. 
+ */
+
+export default [
+  {
+    path: "/api/:version/unsupported_features",
+    method: "get",
+    handler: [
+      checkApiVersion,
+      checkRequiredParams,
+      async (req: Request, res: Response) => {
+        try {
+          const result = await get_unsupported_features(req, res);
+          res.status(res.statusCode).send(result);
+        } catch (err) {
+          throw err;
+        }
+      }
+    ]
+  }
+];

--- a/web/src/services/unsupported_features/unsupported-features-controller.ts
+++ b/web/src/services/unsupported_features/unsupported-features-controller.ts
@@ -1,0 +1,35 @@
+/*
+* CORTX-CSM: CORTX Management web and CLI interface.
+* Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Affero General Public License for more details.
+* You should have received a copy of the GNU Affero General Public License
+* along with this program. If not, see <https://www.gnu.org/licenses/>.
+* For any questions about this software or licensing,
+* please email opensource@seagate.com or cortx-questions@seagate.com.
+*/
+import { Api } from "../api";
+import apiRegister from "../api-register";
+import { Request, Response, request, response } from "express";
+
+/**
+ * This method is responsible to get the unsupported features data from provider and sends back
+ * to client.
+ * @param sortby 
+ * @param sorttype 
+ * @param pagesize 
+ * @param pageno 
+ * @param offset 
+ * @param limit 
+ */
+export const get_unsupported_features = async (req: Request, res: Response) => {
+    let unsupportedFeaturesData = Api.getAll(apiRegister.get_unsupported_features_endpt(req.params.version), req, res);
+    let result = await unsupportedFeaturesData;
+    return result;
+};


### PR DESCRIPTION
# UI
<pre>
  <code>
Get unsupported features from CSM Agent
  </code>
</pre> 

## Problem Statement
<pre>
  <code>
    Story Ref (if any): EOS-20700 : unsupported features support on UI
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
- API to get the unsupported features from CSM agent.
  </code>
</pre>
## Solution/Screenshots
<pre>
  <code>
 Added new GET API to get the unsupported features from CSM Agent.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
API: /api/v2/unsupported_features
Response: {"unsupported_features":["hctl_node","lyve_pilot","health"]}
![image](https://user-images.githubusercontent.com/64407225/119315081-1694d880-bc93-11eb-9eb4-bec868374f83.png)
![image](https://user-images.githubusercontent.com/64407225/119316879-1e557c80-bc95-11eb-8edb-6213a9d12fb3.png)

  </code>
</pre>

Signed-off-by: Soniya Moholkar <soniya.moholkar@seagate.com>