### PR TITLE
EOS-21111: Unique id for tabs in alert page

### DIFF
--- a/gui/src/components/widgets/cortx-tabs.vue
+++ b/gui/src/components/widgets/cortx-tabs.vue
@@ -20,7 +20,7 @@
       v-for="tab in tabsInfo.tabs"
       v-bind:key="tab.id"
       v-if="tab.show"
-      :id="tab.requiredAccess + 'tab'"
+      :id="`tab-${tab.id}`"
       :class="tab.id === tabsInfo.selectedTab ? 'cortx-tab-active' : 'cortx-tab'"
       @click="tabsInfo.selectedTab = tab.id"
     >


### PR DESCRIPTION
Signed-off-by: Naresh Gopalakrishnan <naresh.gopalakrishnan@seagate.com>

## Problem Statement
<pre>
<code>
EOS-21111:CSM-UI: CSM: Stable#204: Alert tabs must have different IDs
</code>
</pre>
## Unit testing on RPM done
<pre>
<code>
No
</code>
</pre>
## Problem Description
<pre>
<code>
'id' attribute for the tabs in alert tabs must have different IDs
</code>
</pre>
## Solution/Screenshots
Before - 'id' attribute of the tab is not unique

![image](https://user-images.githubusercontent.com/52106625/121649204-f7c97b00-cab5-11eb-8682-b0fa180d2438.png)

After- 'id' attribute of the tab is unique

![image](https://user-images.githubusercontent.com/52106625/121649333-1af42a80-cab6-11eb-9c84-1df73e257b47.png)

## Unit Test Cases
<pre>
<code>
Tested whether UI is rendered properly and 'id' attribute is unique for cortx-tab.
</code>
</pre>