### PR TITLE
EOS 21407 Styles to the failed status of health data

### DIFF
--- a/gui/src/common/health-table-headers.ts
+++ b/gui/src/common/health-table-headers.ts
@@ -50,6 +50,7 @@ export const healthTableHeaders = {
             "mapValueToClassName": {
                 "online": "cortx-cluster-status cortx-status-online",
                 "offline": "cortx-cluster-status cortx-status-offline",
+                "failed": "cortx-cluster-status cortx-status-failed",
                 "degraded": "cortx-cluster-status cortx-status-degraded",
                 "unknown": "cortx-cluster-status cortx-status-unknown"
               }

--- a/gui/src/common/health-table-headers.ts
+++ b/gui/src/common/health-table-headers.ts
@@ -1,0 +1,70 @@
+/*
+* CORTX-CSM: CORTX Management web and CLI interface.
+* Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Affero General Public License for more details.
+* You should have received a copy of the GNU Affero General Public License
+* along with this program. If not, see <https://www.gnu.org/licenses/>.
+* For any questions about this software or licensing,
+* please email opensource@seagate.com or cortx-questions@seagate.com.
+*/
+export const healthTableHeaders = {
+    healthTableHeaderList: [
+        {
+          "field_id": "resource",
+          "label": "Resource",
+          "display_id": 201,
+          "sortable": false,
+          "filterable": false,
+          "display": true,
+          "value": {
+            "type": "text"
+            }
+        },
+        {
+          "field_id": "id",
+          "label": "Resource ID",
+          "display_id": 201,
+          "sortable": false,
+          "filterable": false,
+          "display": true,
+          "value": {
+            "type": "text"
+            }
+        },
+        {
+          "field_id": "status",
+          "label": "Status",
+          "display_id": 201,
+          "sortable": false,
+          "filterable": false,
+          "display": true,
+          "value": {
+            "type": "image",
+            "mapValueToClassName": {
+                "online": "cortx-cluster-status cortx-status-online",
+                "offline": "cortx-cluster-status cortx-status-offline",
+                "degraded": "cortx-cluster-status cortx-status-degraded",
+                "unknown": "cortx-cluster-status cortx-status-unknown"
+              }
+          }
+        },
+        {
+          "field_id": "last_updated_time",
+          "label": "Last Updated",
+          "display_id": 201,
+          "sortable": false,
+          "filterable": false,
+          "display": true,
+          "value": {
+            "type": "date"
+            }
+        },
+    ]
+}

--- a/gui/src/common/style.css
+++ b/gui/src/common/style.css
@@ -566,7 +566,8 @@ tbody tr:hover {
 .cortx-status-online {
   background: #6ebe49;
 }
-.cortx-status-offline {
+.cortx-status-offline,
+.cortx-status-failed {
   background: #dc1f2e;
 }
 .cortx-status-degraded {

--- a/gui/src/common/style.css
+++ b/gui/src/common/style.css
@@ -557,6 +557,26 @@ tbody tr:hover {
   ) !important;
 }
 
+/* Health cluster Status style rules --- Start */
+.cortx-cluster-status {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+}
+.cortx-status-online {
+  background: #6ebe49;
+}
+.cortx-status-offline {
+  background: #dc1f2e;
+}
+.cortx-status-degraded {
+  background: #f7a528;
+}
+.cortx-status-unknown {
+  background: #9e9e9e;
+}
+/* Health cluster Status style rules --- End */
+
 /* Status chips style rules --- Start */
 .cortx-status-chip {
   height: 16px;

--- a/gui/src/components/health/cortx-health-tabular.vue
+++ b/gui/src/components/health/cortx-health-tabular.vue
@@ -1,0 +1,70 @@
+/*
+* CORTX-CSM: CORTX Management web and CLI interface.
+* Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Affero General Public License for more details.
+* You should have received a copy of the GNU Affero General Public License
+* along with this program. If not, see <https://www.gnu.org/licenses/>.
+* For any questions about this software or licensing,
+* please email opensource@seagate.com or cortx-questions@seagate.com.
+*/
+<template>
+  <div v-feature="unsupportedFeatures.health">
+          <cortx-data-table
+            :headers="healthTableHeaderList" 
+            :records="clusterHealthData.data"
+            :hideFilter="hideFilter"
+            :onSort={}
+            :onFilter={} 
+            :sortParams={}
+            :rowsPerPage="[10, 20, 30, 50, 100, 150, 200]" 
+            @update:items-per-page="getHealthData()"
+            @update:page="getHealthData()"
+          />
+  </div>
+</template>
+<script lang="ts">
+import { Component, Vue, Prop, Mixins } from "vue-property-decorator";
+import { AuditLogQueryParam } from "../../models/download";
+import { Api } from "../../services/api";
+import apiRegister from "../../services/api-register";
+import { unsupportedFeatures } from "../../common/unsupported-feature";
+import CortxDataTable from "../widgets/cortx-data-table.vue";
+import { healthTableHeaders } from "../../common/health-table-headers"
+@Component({
+  name: "cortx-auditlog",
+  components: { CortxDataTable }
+})
+export default class CortxHealthTabular extends Vue {
+  public unsupportedFeatures = unsupportedFeatures;
+  public healthTableHeaders = healthTableHeaders;
+  public hideFilter: boolean = true;
+  public healthQueryParams: any = {};
+  public healthTableHeaderList: any[] = [];
+  public clusterHealthData: any = {};
+  public mounted() {
+    this.getHealthData();    
+  }  
+  public async getHealthData() {
+    this.healthQueryParams = {
+      response_format: 'flattened',
+      offset: 1,
+      limit: 0
+    }
+    this.$store.dispatch("systemConfig/showLoader", "Fetching health...");
+    const res = await Api.getAll(apiRegister.health_cluster,
+      this.healthQueryParams
+    );
+    this.clusterHealthData = res.data;
+    this.healthTableHeaderList = healthTableHeaders.healthTableHeaderList;
+    this.$store.dispatch("systemConfig/hideLoader");
+  }
+}
+</script>
+<style lang="scss" scoped></style>

--- a/gui/src/components/health/cortx-health.vue
+++ b/gui/src/components/health/cortx-health.vue
@@ -15,15 +15,45 @@
 * please email opensource@seagate.com or cortx-questions@seagate.com.
 */
 <template>
-  <router-view class="cortx-p-1"></router-view>
+  <div class="cortx-p-1">
+    <cortx-tabs :tabsInfo="tabsInfo" />
+      <CortxHealthTabular v-if="showTableTab" />
+  </div>
 </template>
  <script lang="ts">
-import { Component, Vue, Prop } from "vue-property-decorator";
-
+import CortxTabs, { TabsInfo } from "../widgets/cortx-tabs.vue";
+import { Component, Vue, Prop, Watch } from "vue-property-decorator";
+import CortxHealthTabular from "./cortx-health-tabular.vue";
 @Component({
-  name: "cortx-health"
+  name: "cortx-health",
+  components: {
+    CortxTabs,
+    CortxHealthTabular
+  }
 })
-export default class CortxHealth extends Vue {}
+export default class CortxHealth extends Vue {
+  public tabsInfo: TabsInfo = {
+    tabs: [
+      {
+        id: 1,
+        label: "Tabular",
+        show: true,
+        requiredAccess: "health"
+      }
+    ],
+    selectedTab: 1
+  };
+  private showTableTab: boolean = true;
+  
+  @Watch("tabsInfo.selectedTab")
+  public onPropertyChanged(value: number, oldValue: number) {
+    switch (value) {
+      case 1:
+        this.showTableTab = true;
+        break;
+    }
+  }
+}
 </script>
 <style lang="scss" scoped>
 </style>

--- a/gui/src/services/api-register.ts
+++ b/gui/src/services/api-register.ts
@@ -69,6 +69,7 @@ export default {
   health_components: `api/${version}/system/health/components`,
   system_status: `/api/${version}/system/status`,
   health_resources: `api/${version}/system/health/resources`,
+  health_cluster: `api/${version}/system/health/node`,
   appliance_info: `/api/${version}/appliance_info`,
   udx_saas: `/api/${version}/udx_saas`,
   ssl_details: `/api/${version}/tls/bundle/details`

--- a/web/src/services/api-register.ts
+++ b/web/src/services/api-register.ts
@@ -64,6 +64,7 @@ export default {
   get_product_version_endpt: (version :string) => `/api/${version}/product_version`,
   get_health_components_endpt: (version :string) => `/api/${version}/system/health/components`,
   get_health_resources_endpt: (version :string) => `/api/${version}/system/health/resources`,
+  get_health_cluster_endpt: (version :string, resource: string) => `/api/${version}/system/health/${resource}`,
   get_system_status_endpt: (version :string) => `/api/${version}/system/status`,
   get_appliance_info_endpt: (version :string) => `/api/${version}/appliance_info`,
   get_unsupported_features_endpt: (version :string) => `/api/${version}/unsupported_features`

--- a/web/src/services/system/routes.ts
+++ b/web/src/services/system/routes.ts
@@ -23,6 +23,7 @@ import {
   getHealthSummary,
   getHealthView,
   getNodeHealth,
+  getClusterHealth,
   getHealthComponents,
   getHealthResources
 } from "./system-controller";
@@ -123,6 +124,22 @@ export default [
       async (req: Request, res: Response) => {
         try {
           const result = await getNodeStatus(req, res);
+          res.status(res.statusCode).send(result);
+        } catch (err) {
+          throw err;
+        }
+      }
+    ]
+  },  
+  {
+    path: "/api/:version/system/health/:resource",
+    method: "get",
+    handler: [
+      checkApiVersion,
+      checkRequiredParams,
+      async (req: Request, res: Response) => {
+        try {
+          const result = await getClusterHealth(req, res);
           res.status(res.statusCode).send(result);
         } catch (err) {
           throw err;

--- a/web/src/services/system/system-controller.ts
+++ b/web/src/services/system/system-controller.ts
@@ -48,6 +48,10 @@ export const getNodeHealth = async (req: Request, res: Response)=> {
     return healthSummaryData;
 }
 
+export const getClusterHealth = async (req: Request, res: Response)=> {
+  let healthClusterData = await Api.getAll(apiRegister.get_health_cluster_endpt(req.params.version, req.params.resource), req, res);
+  return healthClusterData;
+}
 
 /**
  * This is responsible to fetching node status.


### PR DESCRIPTION
# Frontend

# Problem Statement

- _Overview: JIRA number/GitHub Issue added to PR: [Y/N]:_
- _Describe the problem this patch intends to solve._

## Design

- _For Bug describe the fix here._
- _For feature, post the link to the solution page._
- _Any northbound interface change and has been notified to other gatekeepers [Y/N]:_


## Coding

- _Coding conventions are followed and code is consistent. Yes/No?_
- _Confirm All CODACY errors are resolved. Yes/No?_

## Testing

- _Confirm that Test Cases are added (for both the cases, fix and feature). Yes/No?_
- _Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability. Yes/No?_
- _Confirm Testing was performed with installed RPM. Yes/No?_
- _Confirm all the ut/regression/smoke test has been performed [Y/N]_

## Checklist

- _PR is self-reviewed? Yes/No?_
- _GitHub Issue is updated_
- _Jira is updated_
  -  _Check if the description is clear and explained._ 
    -  _Check Acceptance Criterion is defined._
      -  _All the tests performed should be mentioned before Resolving a JIRA._
        -  _Verification needs to be done before marked as Closed/Verified_
        - _Any interface change Yes/No?_
        - _Change notified to other gatekeepers: Yes/No?_
        - _Code reviews done and addressed: Yes/No?_
        - _Codacy issues reviewed and addressed: Yes/No?_
        - _Deployment test : Done/Not?_
        - _UT/smoke test: Done/Not?_
        - _Jira number added to PR: Yes/No?_
        - _Github merge done using UI: Yes/No?_
        - _Side effects on other features - deployment/update/node-replacement_
        - _Changes to quick-start-guide/community impact_
        - _All dependent component code PR are raised or already merged Yes/No_
        - _All dependent code already merged in landing branch Yes/No_

#Solution/ Screenshot
Tested with mock data for failed status

![image](https://user-images.githubusercontent.com/71690421/122870473-565ee680-d34b-11eb-9a2a-99e5e091bb7e.png)
