### PR TITLE
EOS 21407 Adding styles in the table for failed status

### DIFF
--- a/gui/src/common/health-table-headers.ts
+++ b/gui/src/common/health-table-headers.ts
@@ -50,6 +50,7 @@ export const healthTableHeaders = {
             "mapValueToClassName": {
                 "online": "cortx-cluster-status cortx-status-online",
                 "offline": "cortx-cluster-status cortx-status-offline",
+                "failed": "cortx-cluster-status cortx-status-failed",
                 "degraded": "cortx-cluster-status cortx-status-degraded",
                 "unknown": "cortx-cluster-status cortx-status-unknown"
               }

--- a/gui/src/common/style.css
+++ b/gui/src/common/style.css
@@ -566,7 +566,8 @@ tbody tr:hover {
 .cortx-status-online {
   background: #6ebe49;
 }
-.cortx-status-offline {
+.cortx-status-offline,
+.cortx-status-failed {
   background: #dc1f2e;
 }
 .cortx-status-degraded {


### PR DESCRIPTION
# Frontend

# Problem Statement

- _Overview: JIRA number/GitHub Issue added to PR: [Y/N]:_
- _Describe the problem this patch intends to solve._

## Design

- _For Bug describe the fix here._
- _For feature, post the link to the solution page._
- _Any northbound interface change and has been notified to other gatekeepers [Y/N]:_


## Coding

- _Coding conventions are followed and code is consistent. Yes/No?_
- _Confirm All CODACY errors are resolved. Yes/No?_

## Testing

- _Confirm that Test Cases are added (for both the cases, fix and feature). Yes/No?_
- _Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability. Yes/No?_
- _Confirm Testing was performed with installed RPM. Yes/No?_
- _Confirm all the ut/regression/smoke test has been performed [Y/N]_

## Checklist

- _PR is self-reviewed? Yes/No?_
- _GitHub Issue is updated_
- _Jira is updated_
  -  _Check if the description is clear and explained._ 
    -  _Check Acceptance Criterion is defined._
      -  _All the tests performed should be mentioned before Resolving a JIRA._
        -  _Verification needs to be done before marked as Closed/Verified_
        - _Any interface change Yes/No?_
        - _Change notified to other gatekeepers: Yes/No?_
        - _Code reviews done and addressed: Yes/No?_
        - _Codacy issues reviewed and addressed: Yes/No?_
        - _Deployment test : Done/Not?_
        - _UT/smoke test: Done/Not?_
        - _Jira number added to PR: Yes/No?_
        - _Github merge done using UI: Yes/No?_
        - _Side effects on other features - deployment/update/node-replacement_
        - _Changes to quick-start-guide/community impact_
        - _All dependent component code PR are raised or already merged Yes/No_
        - _All dependent code already merged in landing branch Yes/No_

#solution/Screenshots

Tested with mock data for failed status

![image](https://user-images.githubusercontent.com/71690421/122891920-8a91d180-d362-11eb-951b-707267aee2a0.png)
