### PR TITLE
EOS-22099 - CSM User reset password issue

### DIFF
--- a/gui/src/components/onboarding/system-config/user-settings/user-setting-local.vue
+++ b/gui/src/components/onboarding/system-config/user-settings/user-setting-local.vue
@@ -397,6 +397,55 @@
                         >{{ $t("onBoarding.changePassword") }}</v-expansion-panel-header
                       >
                       <v-expansion-panel-content>
+                        <v-row v-if="selectedItem.username === loggedInUserDetails.username">
+                          <v-col cols="12">
+                            <div
+                              class="cortx-form-group-custom"
+                              :class="{
+                                'cortx-form-group--error':
+                                  $v.selectedItem.current_password.$error
+                              }"
+                            >
+                              <label
+                                class="cortx-form-group-label"
+                                for="password"
+                                id="localuser-oldpasswordlbl"
+                              >
+                                <cortx-info-tooltip
+                                  class="cuttenr-password-tooltip"
+                                  label="Current password*"
+                                  :message="currentPasswordTooltip"
+                                />
+                              </label>
+                              <input
+                                class="cortx-form__input_text"
+                                type="password"
+                                name="txtEditOldPassword"
+                                v-model.trim="selectedItem.current_password"
+                                @input="$v.selectedItem.current_password.$touch"
+                                id="txtLocalOldPass"
+                              />
+                              <div class="cortx-form-group-label cortx-form-group-error-msg">
+                                <label
+                                  id="localuser-oldpass-required"
+                                  v-if="
+                                    $v.selectedItem.current_password.$dirty &&
+                                      !$v.selectedItem.current_password.required
+                                  "
+                                  >{{ $t("csmuser.current-pass-required") }}</label
+                                >
+                                <label
+                                  id="localuser-oldpass-invalid"
+                                  v-else-if="
+                                    $v.selectedItem.current_password.$dirty &&
+                                      !$v.selectedItem.current_password.passwordRegex
+                                  "
+                                  >{{ $t("csmuser.current-password-invalid") }}</label
+                                >
+                              </div>
+                            </div>
+                          </v-col>
+                        </v-row>
                         <v-row>
                           <v-col class="pb-0 col-6">
                             <div
@@ -479,61 +528,6 @@
                       </v-expansion-panel-content>
                     </v-expansion-panel>
                   </v-expansion-panels>
-                  </v-col>
-                </v-row>
-                <v-row>
-                  <v-col cols="12">
-                    <div
-                      class="cortx-form-group-custom"
-                      v-if="
-                        isAdminUser(selectedItem) ||
-                          strEqualityCaseInsensitive(
-                            selectedItem.username,
-                            loggedInUserName
-                          )
-                      "
-                      :class="{
-                        'cortx-form-group--error':
-                          $v.selectedItem.current_password.$error
-                      }"
-                    >
-                      <label
-                        class="cortx-form-group-label"
-                        for="password"
-                        id="localuser-oldpasswordlbl"
-                      >
-                        <cortx-info-tooltip
-                          label="Current password*"
-                          :message="currentPasswordTooltip"
-                        />
-                      </label>
-                      <input
-                        class="cortx-form__input_text"
-                        type="password"
-                        name="txtEditOldPassword"
-                        v-model.trim="selectedItem.current_password"
-                        @input="$v.selectedItem.current_password.$touch"
-                        id="txtLocalOldPass"
-                      />
-                      <div class="cortx-form-group-label cortx-form-group-error-msg">
-                        <label
-                          id="localuser-oldpass-required"
-                          v-if="
-                            $v.selectedItem.current_password.$dirty &&
-                              !$v.selectedItem.current_password.required
-                          "
-                          >{{ $t("csmuser.current-pass-required") }}</label
-                        >
-                        <label
-                          id="localuser-oldpass-invalid"
-                          v-else-if="
-                            $v.selectedItem.current_password.$dirty &&
-                              !$v.selectedItem.current_password.passwordRegex
-                          "
-                          >{{ $t("csmuser.current-password-invalid") }}</label
-                        >
-                      </div>
-                    </div>
                   </v-col>
                 </v-row>
                 <v-row>
@@ -909,7 +903,7 @@ export default class CortxUserSettingLocal extends Vue {
           break;
 
         case this.ROLES.MANAGE:
-          if((this.loggedInUserDetails.username === record.username)
+          if((record.role === this.ROLES.MANAGE)
             || (record.role === this.ROLES.MONITOR)) {
             allowEditOption = true;
           }


### PR DESCRIPTION
# Frontend

# Problem Statement

- _Overview: JIRA number/GitHub Issue added to PR: [Y/N]:_ EOS-22099
- _Describe the problem this patch intends to solve._ Manage user is not able to reset password of users with manage role from csm UI

## Design

- _For Bug describe the fix here._
- _For feature, post the link to the solution page._
- _Any northbound interface change and has been notified to other gatekeepers [Y/N]:_


## Coding

- _Coding conventions are followed and code is consistent. Yes/No?_ Yes
- _Confirm All CODACY errors are resolved. Yes/No?_ Yes

## Testing

- _Confirm that Test Cases are added (for both the cases, fix and feature). Yes/No?_ No
- _Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability. Yes/No?_ No
- _Confirm Testing was performed with installed RPM. Yes/No?_ No
- _Confirm all the ut/regression/smoke test has been performed [Y/N]_ No

## Checklist

- _PR is self-reviewed? Yes/No?_ Yes
- _GitHub Issue is updated_ 
- _Jira is updated_
  -  _Check if the description is clear and explained._ 
    -  _Check Acceptance Criterion is defined._
      -  _All the tests performed should be mentioned before Resolving a JIRA._
        -  _Verification needs to be done before marked as Closed/Verified_
        - _Any interface change Yes/No?_ Yes
        - _Change notified to other gatekeepers: Yes/No?_
        - _Code reviews done and addressed: Yes/No?_
        - _Codacy issues reviewed and addressed: Yes/No?_
        - _Deployment test : Done/Not?_
        - _UT/smoke test: Done/Not?_
        - _Jira number added to PR: Yes/No?_
        - _Github merge done using UI: Yes/No?_
        - _Side effects on other features - deployment/update/node-replacement_
        - _Changes to quick-start-guide/community impact_
        - _All dependent component code PR are raised or already merged Yes/No_
        - _All dependent code already merged in landing branch Yes/No_

![image](https://user-images.githubusercontent.com/81350254/124235444-15dd3680-daca-11eb-8e55-1fa2351e525e.png)

## Current password field is inside the change password tray.
![image](https://user-images.githubusercontent.com/81350254/124235136-c139bb80-dac9-11eb-84d6-b7e18af215b6.png)
