### PR TITLE
EOS-24103: Remove copying systemd configuration for csm_web.spec

### DIFF
--- a/cicd/csm_web.spec
+++ b/cicd/csm_web.spec
@@ -42,8 +42,6 @@ CSM_DIR=<CSM_PATH>
 CFG_DIR=$CSM_DIR/conf
 PRODUCT=<PRODUCT>
 [ -d "${CSM_DIR}/gui" ] && {
-    cp -f $CFG_DIR/service/csm_web.service /etc/systemd/system/csm_web.service
-
     ENV=$CSM_DIR/web/web-dist/.env
     sed -i "s|CSM_UI_PATH=\"/\"|CSM_UI_PATH=\"${CSM_DIR}/gui/ui-dist\"|g" $ENV
     sed -i "s/NODE_ENV=\"development\"/NODE_ENV=\"production\"/g" $ENV
@@ -52,14 +50,18 @@ exit 0
 
 %preun
 [ $1 -eq 1 ] && exit 0
-systemctl disable csm_web
-systemctl stop csm_web
+[ -f /etc/systemd/system/csm_web.service ] && {
+    systemctl disable csm_web
+    systemctl stop csm_web
+}
 
 %postun
 [ $1 -eq 1 ] && exit 0
 rm -f /usr/bin/csm_web 2> /dev/null;
-rm -rf /etc/systemd/system/csm_web.service 2> /dev/null;
-systemctl daemon-reload
+[ -f /etc/systemd/system/csm_web.service ] && {
+    rm -rf /etc/systemd/system/csm_web.service 2> /dev/null;
+    systemctl daemon-reload
+}
 exit 0
 
 %clean


### PR DESCRIPTION
# Frontend

# Problem Statement

- [EOS-24103](https://jts.seagate.com/browse/EOS-24103)
- Remove SystemD dependency.

## Design

- Remove copying of systemd's configuration from the csm_web.spec.


## Coding

- _Coding conventions are followed and code is consistent. Yes/No?_ Yes
- _Confirm All CODACY errors are resolved. Yes/No?_ Yes

## Testing

- _Confirm that Test Cases are added (for both the cases, fix and feature). Yes/No?_ Yes
- _Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability. Yes/No?_ Yes
- _Confirm Testing was performed with installed RPM. Yes/No?_ Yes
- _Confirm all the ut/regression/smoke test has been performed [Y/N]_ Y

## Checklist

- _PR is self-reviewed? Yes/No?_ Yes
- _GitHub Issue is updated_ No
- _Jira is updated_ Yes
  -  _Check if the description is clear and explained._ Yes
    -  _Check Acceptance Criterion is defined._ Yes
      -  _All the tests performed should be mentioned before Resolving a JIRA._ Yes
        -  _Verification needs to be done before marked as Closed/Verified_ Yes
        - _Any interface change Yes/No?_ No
        - _Change notified to other gatekeepers: Yes/No?_ No
        - _Code reviews done and addressed: Yes/No?_ Yes
        - _Codacy issues reviewed and addressed: Yes/No?_ Yes
        - _Deployment test : Done/Not?_ Yes
        - _UT/smoke test: Done/Not?_ Yes
        - _Jira number added to PR: Yes/No?_ Yes
        - _Github merge done using UI: Yes/No?_ Yes
        - _Side effects on other features - deployment/update/node-replacement_ No
        - _Changes to quick-start-guide/community impact_ No
        - _All dependent component code PR are raised or already merged Yes/No_ Yes
        - _All dependent code already merged in landing branch Yes/No_ Yes
